### PR TITLE
can now delete and update posts/threads

### DIFF
--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::PostsController < ApplicationController
-  before_action :set_post, only: %i[show destroy]
+  before_action :set_post, only: %i[show destroy update]
+  before_action :authenticate_user, only: %i[show create update destroy]
 
   def index
     posts = Post.all.order(created_at: :desc)
@@ -11,56 +12,71 @@ class Api::V1::PostsController < ApplicationController
   end
 
   def create
-    token = params[:token]
-    begin
-      decoded_token = JWT.decode(token, jwt_key, true, algorithm: 'HS256')
-      puts decoded_token
-      if decoded_token && decoded_token[0] && decoded_token[0]['user_id']
-        user_id = decoded_token[0]['user_id']
-        puts "User ID: #{user_id}"
-      else
-        puts 'User ID not found in the decoded token'
-      end
-      # user_id_string = decoded_token["user_id"]
+    puts post_params
+    post = Post.create!(post_params)
 
-      # if user_id_string =~ /\A\d+\z/ # Check if the string contains only digits
-      #   user_id = user_id_string.to_i
-      #   # Further processing with the user_id as an integer
-      # else
-      #   puts user_id
-      user = User.find_by(id: user_id)
-      puts user.id
-      post = Post.create!(post_params.merge(user_id: user.id))
-      if post
-        render json: post
-      else
-        render jsdon: post.errors
-      end
-    rescue JWT::DecodeError => e
-      return { error: e.message }
+    if post
+      render json: post
+    else
+      render json: { error: post.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @post.update(post_params)
+      render json: @post
+    else
+      render json: { error: @post.errors.full_messages }, status: :unprocessable_entity
     end
   end
 
   def show
-    render json: @post
+    render json: {
+      post: @post,
+      is_owner: current_user_is_owner?
+    }
   end
 
   def destroy
-    @post&.destroy
-    render json: {message: 'Post deleted'}
+    @post.destroy
+    render json: { message: 'Post deleted' }
   end
 
   private
+
+  def authenticate_user
+    params.permit(:token, :id, post:{})
+    token = params[:token]
+    decoded_token = JWT.decode(token, jwt_key, true, algorithm: 'HS256')
+
+    if decoded_token && decoded_token[0] && decoded_token[0]['user_id']
+      @current_user = User.find_by(id: decoded_token[0]['user_id'])
+    else
+      render json: { error: 'User ID not found in the decoded token' }, status: :unprocessable_entity
+    end
+  rescue JWT::DecodeError => e
+    render json: { error: e.message }, status: :unprocessable_entity
+  end
 
   def jwt_key
     Rails.application.credentials.jwt_key
   end
 
+  def current_user
+    @current_user
+  end
+
   def post_params
-    params.permit(:title, :category, :content)
+    params.require(:post).permit(:title, :category, :content).merge(user_id: current_user.id)
   end
 
   def set_post
+    params.permit(:id, :token, post: {})
+    puts "set"
     @post = Post.find(params[:id])
+  end
+
+  def current_user_is_owner?
+    @post.user_id == current_user.id
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,9 @@ Rails.application.routes.draw do
     namespace :v1 do
       get 'posts/index'
       post 'posts/create'
-      get '/show/:id', to: 'posts#show'
+      post 'show/:id', to: 'posts#show'
       delete 'destroy/:id', to: 'posts#destroy'
+      patch 'update/:id', to: 'posts#update'
     end
   end
   post '/login', to: 'authentication#create'

--- a/log/development.log
+++ b/log/development.log
@@ -3830,3 +3830,6110 @@ Processing by Api::V1::PostsController#index as */*
 Completed 200 OK in 4ms (Views: 0.6ms | ActiveRecord: 0.8ms | Allocations: 1362)
 
 
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:17:34 +0800
+  [1m[36mActiveRecord::SchemaMigration Load (1.3ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 114ms (Views: 0.7ms | ActiveRecord: 12.1ms | Allocations: 32453)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:17:34 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (2.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 10ms (Views: 0.9ms | ActiveRecord: 2.9ms | Allocations: 1365)
+
+
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 15:17:38 +0800
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 15:17:38 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:102:in `set_post'
+Processing by Api::V1::PostsController#show as */*
+  [1m[36mUser Load (1.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+  ↳ app/controllers/api/v1/posts_controller.rb:71:in `show'
+Completed 200 OK in 59ms (Views: 0.3ms | ActiveRecord: 1.4ms | Allocations: 2842)
+
+
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:102:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:71:in `show'
+Completed 200 OK in 16ms (Views: 0.4ms | ActiveRecord: 5.4ms | Allocations: 4220)
+
+
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 15:19:43 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:102:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:71:in `show'
+Completed 200 OK in 4ms (Views: 0.6ms | ActiveRecord: 0.5ms | Allocations: 1048)
+
+
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 15:19:52 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:102:in `set_post'
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 15:19:52 +0800
+  [1m[36mUser Load (2.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:71:in `show'
+Completed 200 OK in 9ms (Views: 0.5ms | ActiveRecord: 2.6ms | Allocations: 1343)
+
+
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:102:in `set_post'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:71:in `show'
+Completed 200 OK in 6ms (Views: 0.7ms | ActiveRecord: 0.8ms | Allocations: 1035)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:19:56 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (1.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 9ms (Views: 0.7ms | ActiveRecord: 1.7ms | Allocations: 1361)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:19:56 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 6ms (Views: 0.5ms | ActiveRecord: 0.9ms | Allocations: 1361)
+
+
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 15:19:57 +0800
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 15:19:57 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+  [1m[36mPost Load (0.8ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:102:in `set_post'
+Completed 422 Unprocessable Entity in 5ms (Views: 0.3ms | ActiveRecord: 0.8ms | Allocations: 953)
+
+
+  [1m[36mPost Load (1.9ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:102:in `set_post'
+Completed 422 Unprocessable Entity in 7ms (Views: 0.2ms | ActiveRecord: 1.9ms | Allocations: 1222)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:19:57 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.9ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 9ms (Views: 0.6ms | ActiveRecord: 1.2ms | Allocations: 1361)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:19:57 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 6ms (Views: 0.7ms | ActiveRecord: 1.0ms | Allocations: 1361)
+
+
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 15:20:48 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 15:20:48 +0800
+  [1m[36mPost Load (0.8ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:102:in `set_post'
+Completed 422 Unprocessable Entity in 6ms (Views: 0.2ms | ActiveRecord: 0.7ms | Allocations: 879)
+
+
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:102:in `set_post'
+Completed 422 Unprocessable Entity in 3ms (Views: 0.3ms | ActiveRecord: 0.3ms | Allocations: 509)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:20:48 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 7ms (Views: 0.8ms | ActiveRecord: 1.0ms | Allocations: 1361)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:20:48 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 5ms (Views: 0.7ms | ActiveRecord: 0.9ms | Allocations: 1361)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:28:13 +0800
+  [1m[36mActiveRecord::SchemaMigration Load (1.4ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+  
+SyntaxError (/home/pengxuan/CVWO/CVWO_backend/app/controllers/api/v1/posts_controller.rb:82: syntax error, unexpected local variable or method, expecting '}'
+        is_owner: false
+        ^~~~~~~~
+):
+  
+app/controllers/api/v1/posts_controller.rb:82: syntax error, unexpected local variable or method, expecting '}'
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:28:14 +0800
+  
+SyntaxError (/home/pengxuan/CVWO/CVWO_backend/app/controllers/api/v1/posts_controller.rb:82: syntax error, unexpected local variable or method, expecting '}'
+        is_owner: false
+        ^~~~~~~~
+):
+  
+app/controllers/api/v1/posts_controller.rb:82: syntax error, unexpected local variable or method, expecting '}'
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:28:17 +0800
+  
+SyntaxError (/home/pengxuan/CVWO/CVWO_backend/app/controllers/api/v1/posts_controller.rb:82: syntax error, unexpected local variable or method, expecting '}'
+        is_owner: false
+        ^~~~~~~~
+):
+  
+app/controllers/api/v1/posts_controller.rb:82: syntax error, unexpected local variable or method, expecting '}'
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:28:17 +0800
+  
+SyntaxError (/home/pengxuan/CVWO/CVWO_backend/app/controllers/api/v1/posts_controller.rb:82: syntax error, unexpected local variable or method, expecting '}'
+        is_owner: false
+        ^~~~~~~~
+):
+  
+app/controllers/api/v1/posts_controller.rb:82: syntax error, unexpected local variable or method, expecting '}'
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:29:34 +0800
+  [1m[36mActiveRecord::SchemaMigration Load (1.2ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 102ms (Views: 1.2ms | ActiveRecord: 16.9ms | Allocations: 32453)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:29:35 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 6ms (Views: 0.5ms | ActiveRecord: 0.9ms | Allocations: 1365)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:29:41 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (3.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 72ms (Views: 0.5ms | ActiveRecord: 4.1ms | Allocations: 1377)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:29:41 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 6ms (Views: 0.5ms | ActiveRecord: 1.3ms | Allocations: 1361)
+
+
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 15:29:49 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:106:in `set_post'
+Completed 200 OK in 3ms (Views: 0.4ms | ActiveRecord: 0.2ms | Allocations: 768)
+
+
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 15:29:49 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:106:in `set_post'
+Completed 200 OK in 3ms (Views: 0.4ms | ActiveRecord: 0.3ms | Allocations: 565)
+
+
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 15:30:19 +0800
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 15:30:19 +0800
+  
+SyntaxError (/home/pengxuan/CVWO/CVWO_backend/app/controllers/api/v1/posts_controller.rb:81: syntax error, unexpected ',', expecting =>
+        @post,
+             ^
+):
+  
+app/controllers/api/v1/posts_controller.rb:81: syntax error, unexpected ',', expecting =>
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:30:19 +0800
+  
+SyntaxError (/home/pengxuan/CVWO/CVWO_backend/app/controllers/api/v1/posts_controller.rb:81: syntax error, unexpected ',', expecting =>
+        @post,
+             ^
+):
+  
+app/controllers/api/v1/posts_controller.rb:81: syntax error, unexpected ',', expecting =>
+  
+SyntaxError (/home/pengxuan/CVWO/CVWO_backend/app/controllers/api/v1/posts_controller.rb:81: syntax error, unexpected ',', expecting =>
+        @post,
+             ^
+):
+  
+app/controllers/api/v1/posts_controller.rb:81: syntax error, unexpected ',', expecting =>
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:30:19 +0800
+  
+SyntaxError (/home/pengxuan/CVWO/CVWO_backend/app/controllers/api/v1/posts_controller.rb:81: syntax error, unexpected ',', expecting =>
+        @post,
+             ^
+):
+  
+app/controllers/api/v1/posts_controller.rb:81: syntax error, unexpected ',', expecting =>
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:30:27 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 31ms (Views: 0.8ms | ActiveRecord: 7.8ms | Allocations: 9244)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:30:27 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 6ms (Views: 0.9ms | ActiveRecord: 0.9ms | Allocations: 1363)
+
+
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 15:30:28 +0800
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 15:30:28 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+  [1m[36mPost Load (1.0ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:106:in `set_post'
+Completed 200 OK in 5ms (Views: 0.4ms | ActiveRecord: 1.0ms | Allocations: 2056)
+
+
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:106:in `set_post'
+Completed 200 OK in 15ms (Views: 0.7ms | ActiveRecord: 5.6ms | Allocations: 4089)
+
+
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 15:31:06 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:106:in `set_post'
+Completed 200 OK in 2ms (Views: 0.4ms | ActiveRecord: 0.3ms | Allocations: 559)
+
+
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 15:31:30 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:106:in `set_post'
+Completed 200 OK in 2ms (Views: 0.3ms | ActiveRecord: 0.3ms | Allocations: 552)
+
+
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 15:32:30 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:106:in `set_post'
+Completed 200 OK in 4ms (Views: 1.5ms | ActiveRecord: 0.4ms | Allocations: 552)
+
+
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 15:32:30 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:106:in `set_post'
+Completed 200 OK in 4ms (Views: 0.7ms | ActiveRecord: 0.5ms | Allocations: 551)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:32:33 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (1.1ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 7ms (Views: 0.6ms | ActiveRecord: 1.4ms | Allocations: 1363)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:32:33 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 6ms (Views: 0.5ms | ActiveRecord: 1.1ms | Allocations: 1361)
+
+
+Started POST "/api/v1/show/4" for ::1 at 2024-01-01 15:32:34 +0800
+Started POST "/api/v1/show/4" for ::1 at 2024-01-01 15:32:34 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"4", "post"=>{}}
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"4", "post"=>{}}
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 4], ["LIMIT", 1]]
+  [1m[36mPost Load (0.9ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 4], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:106:in `set_post'
+  ↳ app/controllers/api/v1/posts_controller.rb:106:in `set_post'
+Completed 200 OK in 5ms (Views: 0.7ms | ActiveRecord: 0.4ms | Allocations: 885)
+
+
+Completed 200 OK in 6ms (Views: 0.3ms | ActiveRecord: 0.9ms | Allocations: 1148)
+
+
+Started POST "/api/v1/show/4" for ::1 at 2024-01-01 15:32:37 +0800
+Started POST "/api/v1/show/4" for ::1 at 2024-01-01 15:32:37 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"4", "post"=>{}}
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"4", "post"=>{}}
+  [1m[36mPost Load (1.1ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 4], ["LIMIT", 1]]
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 4], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:106:in `set_post'
+  ↳ app/controllers/api/v1/posts_controller.rb:106:in `set_post'
+Completed 200 OK in 7ms (Views: 0.8ms | ActiveRecord: 1.1ms | Allocations: 1294)
+
+
+Completed 200 OK in 6ms (Views: 0.4ms | ActiveRecord: 0.5ms | Allocations: 1067)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:32:38 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 6ms (Views: 0.7ms | ActiveRecord: 1.1ms | Allocations: 1362)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:32:38 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 5ms (Views: 0.6ms | ActiveRecord: 0.9ms | Allocations: 1361)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:32:39 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.8ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 6ms (Views: 0.5ms | ActiveRecord: 1.1ms | Allocations: 1362)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:32:39 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 6ms (Views: 0.5ms | ActiveRecord: 0.9ms | Allocations: 1361)
+
+
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 15:32:41 +0800
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 15:32:41 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+Processing by Api::V1::PostsController#show as */*
+  ↳ app/controllers/api/v1/posts_controller.rb:106:in `set_post'
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+Completed 200 OK in 6ms (Views: 0.4ms | ActiveRecord: 0.6ms | Allocations: 1064)
+
+
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:106:in `set_post'
+Completed 200 OK in 3ms (Views: 0.4ms | ActiveRecord: 0.2ms | Allocations: 785)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:32:42 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 7ms (Views: 0.5ms | ActiveRecord: 1.1ms | Allocations: 1362)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:32:42 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.9ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 7ms (Views: 1.0ms | ActiveRecord: 1.2ms | Allocations: 1361)
+
+
+Started POST "/api/v1/show/4" for ::1 at 2024-01-01 15:32:43 +0800
+Started POST "/api/v1/show/4" for ::1 at 2024-01-01 15:32:43 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"4", "post"=>{}}
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"4", "post"=>{}}
+  [1m[36mPost Load (1.0ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 4], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:106:in `set_post'
+  [1m[36mPost Load (0.8ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 4], ["LIMIT", 1]]
+Completed 200 OK in 6ms (Views: 0.5ms | ActiveRecord: 1.6ms | Allocations: 992)
+
+
+  ↳ app/controllers/api/v1/posts_controller.rb:106:in `set_post'
+Completed 200 OK in 6ms (Views: 0.7ms | ActiveRecord: 0.7ms | Allocations: 1301)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:32:44 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (1.0ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 7ms (Views: 0.6ms | ActiveRecord: 1.3ms | Allocations: 1361)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:32:44 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.9ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 5ms (Views: 0.5ms | ActiveRecord: 1.1ms | Allocations: 1361)
+
+
+Started POST "/login" for ::1 at 2024-01-01 15:32:50 +0800
+Processing by AuthenticationController#create as HTML
+  Parameters: {"username"=>"pengxuan", "password"=>"[FILTERED]", "authentication"=>{"username"=>"pengxuan", "password"=>"[FILTERED]"}}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."username" = $1 LIMIT $2[0m  [["username", "pengxuan"], ["LIMIT", 1]]
+  ↳ app/controllers/authentication_controller.rb:4:in `create'
+Completed 200 OK in 265ms (Views: 0.2ms | ActiveRecord: 0.3ms | Allocations: 898)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:32:52 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 5ms (Views: 0.6ms | ActiveRecord: 0.7ms | Allocations: 1361)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:32:52 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 6ms (Views: 0.6ms | ActiveRecord: 0.8ms | Allocations: 1362)
+
+
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 15:32:53 +0800
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 15:32:53 +0800
+Processing by Api::V1::PostsController#show as */*
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:106:in `set_post'
+  ↳ app/controllers/api/v1/posts_controller.rb:106:in `set_post'
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:71:in `show'
+Completed 200 OK in 7ms (Views: 0.7ms | ActiveRecord: 1.0ms | Allocations: 1675)
+
+
+  [1m[36mUser Load (1.9ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:71:in `show'
+Completed 200 OK in 8ms (Views: 0.4ms | ActiveRecord: 1.4ms | Allocations: 2345)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:32:54 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.8ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 5ms (Views: 0.4ms | ActiveRecord: 1.2ms | Allocations: 1361)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:32:54 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 7ms (Views: 0.6ms | ActiveRecord: 1.2ms | Allocations: 1361)
+
+
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 15:32:56 +0800
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 15:32:56 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:106:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+Processing by Api::V1::PostsController#show as */*
+  ↳ app/controllers/api/v1/posts_controller.rb:71:in `show'
+Completed 200 OK in 6ms (Views: 0.5ms | ActiveRecord: 0.7ms | Allocations: 1545)
+
+
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:106:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:71:in `show'
+Completed 200 OK in 4ms (Views: 0.5ms | ActiveRecord: 0.5ms | Allocations: 1034)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:32:57 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (1.1ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 8ms (Views: 1.7ms | ActiveRecord: 1.3ms | Allocations: 1361)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:32:57 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.9ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 9ms (Views: 0.9ms | ActiveRecord: 1.3ms | Allocations: 1361)
+
+
+Started POST "/login" for ::1 at 2024-01-01 15:33:03 +0800
+Processing by AuthenticationController#create as HTML
+  Parameters: {"username"=>"test", "password"=>"[FILTERED]", "authentication"=>{"username"=>"test", "password"=>"[FILTERED]"}}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."username" = $1 LIMIT $2[0m  [["username", "test"], ["LIMIT", 1]]
+  ↳ app/controllers/authentication_controller.rb:4:in `create'
+Completed 200 OK in 261ms (Views: 0.2ms | ActiveRecord: 0.3ms | Allocations: 566)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:33:06 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 5ms (Views: 0.4ms | ActiveRecord: 0.7ms | Allocations: 1361)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:33:07 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.8ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 6ms (Views: 0.6ms | ActiveRecord: 1.1ms | Allocations: 1361)
+
+
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 15:33:07 +0800
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 15:33:07 +0800
+Processing by Api::V1::PostsController#show as */*
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:106:in `set_post'
+  ↳ app/controllers/api/v1/posts_controller.rb:106:in `set_post'
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:71:in `show'
+  ↳ app/controllers/api/v1/posts_controller.rb:71:in `show'
+Completed 200 OK in 8ms (Views: 0.5ms | ActiveRecord: 1.3ms | Allocations: 1933)
+
+
+Completed 200 OK in 8ms (Views: 0.2ms | ActiveRecord: 1.0ms | Allocations: 2050)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:50:13 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (10.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 22ms (Views: 0.6ms | ActiveRecord: 15.1ms | Allocations: 4140)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 15:50:13 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:6:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `block in index'
+Completed 200 OK in 6ms (Views: 0.5ms | ActiveRecord: 0.8ms | Allocations: 1361)
+
+
+Started POST "/login" for ::1 at 2024-01-01 16:00:08 +0800
+  [1m[36mActiveRecord::SchemaMigration Load (0.9ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+Processing by AuthenticationController#create as HTML
+  Parameters: {"username"=>"pengxuan", "password"=>"[FILTERED]", "authentication"=>{"username"=>"pengxuan", "password"=>"[FILTERED]"}}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."username" = $1 LIMIT $2[0m  [["username", "pengxuan"], ["LIMIT", 1]]
+  ↳ app/controllers/authentication_controller.rb:4:in `create'
+Completed 200 OK in 327ms (Views: 0.3ms | ActiveRecord: 10.2ms | Allocations: 21430)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 16:00:12 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 37ms (Views: 1.0ms | ActiveRecord: 3.8ms | Allocations: 11976)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 16:00:12 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.8ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 119ms (Views: 0.6ms | ActiveRecord: 1.4ms | Allocations: 1364)
+
+
+Started POST "/validate_token" for ::1 at 2024-01-01 16:00:14 +0800
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 1ms (ActiveRecord: 0.0ms | Allocations: 223)
+
+
+Started POST "/validate_token" for ::1 at 2024-01-01 16:00:14 +0800
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 1ms (ActiveRecord: 0.0ms | Allocations: 107)
+
+
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 16:00:19 +0800
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"hi", "category"=>"what", "content"=>"sdsgf", "post"=>{"title"=>"hi", "content"=>"sdsgf", "category"=>"what"}}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 500 Internal Server Error in 4ms (ActiveRecord: 0.5ms | Allocations: 800)
+
+
+  
+NoMethodError (undefined method `posts' for #<User id: 1, username: "pengxuan", password_digest: [FILTERED], created_at: "2023-12-26 03:18:00.053045000 +0000", updated_at: "2023-12-26 03:18:00.053045000 +0000">):
+  
+app/controllers/api/v1/posts_controller.rb:46:in `create'
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 16:02:27 +0800
+  [1m[36mActiveRecord::SchemaMigration Load (1.5ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"hi", "category"=>"what", "content"=>"sdsgf", "post"=>{"title"=>"hi", "content"=>"sdsgf", "category"=>"what"}}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 500 Internal Server Error in 57ms (ActiveRecord: 19.6ms | Allocations: 13716)
+
+
+  
+NoMethodError (undefined method `posts' for #<User id: 1, username: "pengxuan", password_digest: [FILTERED], created_at: "2023-12-26 03:18:00.053045000 +0000", updated_at: "2023-12-26 03:18:00.053045000 +0000">):
+  
+app/controllers/api/v1/posts_controller.rb:46:in `create'
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 16:04:42 +0800
+  [1m[36mActiveRecord::SchemaMigration Load (1.1ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"hi", "category"=>"what", "content"=>"sdsgf", "post"=>{"title"=>"hi", "content"=>"sdsgf", "category"=>"what"}}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:130:in `authenticate_user'
+[31mUnpermitted parameters: :token, :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007ff23ddc5500>, params: {"token"=>"[FILTERED]", "title"=>"hi", "category"=>"what", "content"=>"sdsgf", "controller"=>"api/v1/posts", "action"=>"create", "post"=>{"title"=>"hi", "content"=>"sdsgf", "category"=>"what"}} }[0m
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mPost Create (4.3ms)[0m  [1m[32mINSERT INTO "posts" ("user_id", "title", "content", "category", "like_count", "dislike_count", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING "id"[0m  [["user_id", 1], ["title", "hi"], ["content", "sdsgf"], ["category", "what"], ["like_count", 0], ["dislike_count", 0], ["created_at", "2024-01-01 08:04:42.763528"], ["updated_at", "2024-01-01 08:04:42.763528"]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (10.6ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+Completed 200 OK in 134ms (Views: 5.6ms | ActiveRecord: 39.7ms | Allocations: 26813)
+
+
+Started POST "/api/v1/show/6" for ::1 at 2024-01-01 16:04:42 +0800
+Started POST "/api/v1/show/6" for ::1 at 2024-01-01 16:04:42 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"6", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:155:in `set_post'
+Completed 500 Internal Server Error in 3ms (ActiveRecord: 0.3ms | Allocations: 904)
+
+
+  
+NoMethodError (undefined method `id' for nil:NilClass):
+  
+app/controllers/api/v1/posts_controller.rb:159:in `current_user_is_owner?'
+app/controllers/api/v1/posts_controller.rb:91:in `show'
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"6", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:155:in `set_post'
+Completed 500 Internal Server Error in 2ms (ActiveRecord: 0.3ms | Allocations: 541)
+
+
+  
+NoMethodError (undefined method `id' for nil:NilClass):
+  
+app/controllers/api/v1/posts_controller.rb:159:in `current_user_is_owner?'
+app/controllers/api/v1/posts_controller.rb:91:in `show'
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 16:04:42 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.8ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 7ms (Views: 0.8ms | ActiveRecord: 1.3ms | Allocations: 1954)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 16:04:42 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 8ms (Views: 0.6ms | ActiveRecord: 1.0ms | Allocations: 1838)
+
+
+Started POST "/api/v1/show/6" for ::1 at 2024-01-01 16:04:59 +0800
+Started POST "/api/v1/show/6" for ::1 at 2024-01-01 16:04:59 +0800
+Processing by Api::V1::PostsController#show as */*
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"6", "post"=>{}}
+  Parameters: {"token"=>"[FILTERED]", "id"=>"6", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+Completed 500 Internal Server Error in 13ms (ActiveRecord: 6.1ms | Allocations: 5084)
+
+
+  
+NoMethodError (undefined method `id' for nil:NilClass):
+  
+app/controllers/api/v1/posts_controller.rb:158:in `current_user_is_owner?'
+app/controllers/api/v1/posts_controller.rb:90:in `show'
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+Completed 500 Internal Server Error in 63ms (ActiveRecord: 50.0ms | Allocations: 32187)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 16:04:59 +0800
+  
+NoMethodError (undefined method `id' for nil:NilClass):
+  
+app/controllers/api/v1/posts_controller.rb:158:in `current_user_is_owner?'
+app/controllers/api/v1/posts_controller.rb:90:in `show'
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (1.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 24ms (Views: 0.9ms | ActiveRecord: 6.4ms | Allocations: 5077)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 16:05:00 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.8ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 15ms (Views: 0.9ms | ActiveRecord: 1.8ms | Allocations: 1839)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 16:06:35 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 25ms (Views: 0.7ms | ActiveRecord: 6.6ms | Allocations: 9696)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 16:06:35 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 6ms (Views: 0.5ms | ActiveRecord: 0.9ms | Allocations: 1839)
+
+
+Started POST "/api/v1/show/6" for ::1 at 2024-01-01 16:06:37 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"6", "post"=>{}}
+  [1m[36mPost Load (1.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+Started POST "/api/v1/show/6" for ::1 at 2024-01-01 16:06:37 +0800
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 9ms (Views: 0.7ms | ActiveRecord: 2.1ms | Allocations: 1500)
+
+
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"6", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 5ms (Views: 0.5ms | ActiveRecord: 0.8ms | Allocations: 1037)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 16:06:48 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 7ms (Views: 0.7ms | ActiveRecord: 1.2ms | Allocations: 1837)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 16:06:48 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 11ms (Views: 0.6ms | ActiveRecord: 1.3ms | Allocations: 1837)
+
+
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 16:06:49 +0800
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 16:06:49 +0800
+Processing by Api::V1::PostsController#show as */*
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  [1m[36mPost Load (0.9ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (1.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 8ms (Views: 0.5ms | ActiveRecord: 1.6ms | Allocations: 1881)
+
+
+Completed 200 OK in 10ms (Views: 0.4ms | ActiveRecord: 1.2ms | Allocations: 2105)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 16:06:50 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 7ms (Views: 1.0ms | ActiveRecord: 1.2ms | Allocations: 1837)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 16:06:51 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.8ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 7ms (Views: 0.8ms | ActiveRecord: 1.2ms | Allocations: 1837)
+
+
+Started POST "/api/v1/show/6" for ::1 at 2024-01-01 16:06:51 +0800
+Started POST "/api/v1/show/6" for ::1 at 2024-01-01 16:06:51 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"6", "post"=>{}}
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"6", "post"=>{}}
+  [1m[36mPost Load (0.8ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mPost Load (0.9ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 6ms (Views: 0.6ms | ActiveRecord: 1.0ms | Allocations: 2026)
+
+
+  [1m[36mUser Load (1.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 9ms (Views: 0.9ms | ActiveRecord: 2.1ms | Allocations: 2231)
+
+
+Started DELETE "/api/v1/destroy/6" for ::1 at 2024-01-01 16:08:01 +0800
+Processing by Api::V1::PostsController#destroy as */*
+  Parameters: {"id"=>"6", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+Filter chain halted as :authenticate_user rendered or redirected
+Completed 422 Unprocessable Entity in 2ms (Views: 0.2ms | ActiveRecord: 0.3ms | Allocations: 560)
+
+
+Started DELETE "/api/v1/destroy/6" for ::1 at 2024-01-01 16:08:53 +0800
+Processing by Api::V1::PostsController#destroy as */*
+  Parameters: {"id"=>"6", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+Filter chain halted as :authenticate_user rendered or redirected
+Completed 422 Unprocessable Entity in 2ms (Views: 0.1ms | ActiveRecord: 0.3ms | Allocations: 528)
+
+
+Started POST "/api/v1/show/6" for ::1 at 2024-01-01 16:10:23 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"6", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 7ms (Views: 0.8ms | ActiveRecord: 0.5ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/6" for ::1 at 2024-01-01 16:10:48 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"6", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 4ms (Views: 0.5ms | ActiveRecord: 0.4ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/6" for ::1 at 2024-01-01 16:10:53 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"6", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+Started POST "/api/v1/show/6" for ::1 at 2024-01-01 16:10:53 +0800
+  [1m[36mUser Load (2.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 8ms (Views: 0.6ms | ActiveRecord: 2.3ms | Allocations: 1327)
+
+
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"6", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 5ms (Views: 0.5ms | ActiveRecord: 0.7ms | Allocations: 1037)
+
+
+Started DELETE "/api/v1/destroy/6" for ::1 at 2024-01-01 16:10:55 +0800
+Processing by Api::V1::PostsController#destroy as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"6", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 6], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:118:in `destroy'
+  [1m[36mPost Destroy (1.1ms)[0m  [1m[31mDELETE FROM "posts" WHERE "posts"."id" = $1[0m  [["id", 6]]
+  ↳ app/controllers/api/v1/posts_controller.rb:118:in `destroy'
+  [1m[36mTRANSACTION (1.9ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:118:in `destroy'
+Completed 200 OK in 9ms (Views: 0.3ms | ActiveRecord: 3.5ms | Allocations: 2301)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 16:10:55 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 6ms (Views: 0.9ms | ActiveRecord: 0.9ms | Allocations: 1363)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 16:10:55 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 7ms (Views: 0.5ms | ActiveRecord: 1.0ms | Allocations: 1363)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 18:40:12 +0800
+  
+SyntaxError (/home/pengxuan/CVWO/CVWO_backend/config/routes.rb:8: syntax error, unexpected string literal, expecting `do' or '{' or '('
+...     update '/update/:id', to 'posts#update'
+...                              ^
+):
+  
+config/routes.rb:8: syntax error, unexpected string literal, expecting `do' or '{' or '('
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 18:40:12 +0800
+  
+ActionController::RoutingError (No route matches [GET] "/api/v1/posts/index"):
+  
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 18:40:15 +0800
+  
+ActionController::RoutingError (No route matches [GET] "/api/v1/posts/index"):
+  
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 18:40:15 +0800
+  
+ActionController::RoutingError (No route matches [GET] "/api/v1/posts/index"):
+  
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 18:42:34 +0800
+  [1m[36mActiveRecord::SchemaMigration Load (0.9ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 107ms (Views: 1.4ms | ActiveRecord: 15.6ms | Allocations: 32470)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 18:42:35 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 12ms (Views: 1.6ms | ActiveRecord: 0.9ms | Allocations: 1367)
+
+
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 18:42:48 +0800
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 18:42:48 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 9ms (Views: 1.6ms | ActiveRecord: 0.6ms | Allocations: 2824)
+
+
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 21ms (Views: 0.4ms | ActiveRecord: 10.1ms | Allocations: 5278)
+
+
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 18:43:07 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 4ms (Views: 0.6ms | ActiveRecord: 0.6ms | Allocations: 1052)
+
+
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 18:43:20 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 4ms (Views: 0.5ms | ActiveRecord: 0.6ms | Allocations: 1052)
+
+
+Started POST "/validate_token" for ::1 at 2024-01-01 18:43:28 +0800
+Started POST "/validate_token" for ::1 at 2024-01-01 18:43:28 +0800
+Processing by AuthenticationController#validate as HTML
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 1ms (ActiveRecord: 0.0ms | Allocations: 163)
+
+
+Completed 204 No Content in 0ms (ActiveRecord: 0.0ms | Allocations: 107)
+
+
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 18:43:33 +0800
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"what", "category"=>"sds", "content"=>"sdfsdgsdfgs", "post"=>{"title"=>"what", "content"=>"sdfsdgsdfgs", "category"=>"sds"}}
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+[31mUnpermitted parameters: :token, :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007f3b22428ad8>, params: {"token"=>"[FILTERED]", "title"=>"what", "category"=>"sds", "content"=>"sdfsdgsdfgs", "controller"=>"api/v1/posts", "action"=>"create", "post"=>{"title"=>"what", "content"=>"sdfsdgsdfgs", "category"=>"sds"}} }[0m
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:46:in `create'
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:46:in `create'
+  [1m[36mPost Create (2.6ms)[0m  [1m[32mINSERT INTO "posts" ("user_id", "title", "content", "category", "like_count", "dislike_count", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING "id"[0m  [["user_id", 1], ["title", "what"], ["content", "sdfsdgsdfgs"], ["category", "sds"], ["like_count", 0], ["dislike_count", 0], ["created_at", "2024-01-01 10:43:33.770893"], ["updated_at", "2024-01-01 10:43:33.770893"]]
+  ↳ app/controllers/api/v1/posts_controller.rb:46:in `create'
+  [1m[36mTRANSACTION (1.2ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:46:in `create'
+Completed 200 OK in 21ms (Views: 0.5ms | ActiveRecord: 4.6ms | Allocations: 5153)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:43:33 +0800
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:43:33 +0800
+Processing by Api::V1::PostsController#show as */*
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  [1m[36mPost Load (1.0ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+Completed 200 OK in 8ms (Views: 0.8ms | ActiveRecord: 1.3ms | Allocations: 1604)
+
+
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 11ms (Views: 0.4ms | ActiveRecord: 1.8ms | Allocations: 2342)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:44:24 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 5ms (Views: 0.4ms | ActiveRecord: 0.7ms | Allocations: 1038)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:44:29 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 4ms (Views: 0.3ms | ActiveRecord: 0.6ms | Allocations: 1038)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:44:38 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 5ms (Views: 0.4ms | ActiveRecord: 0.4ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:44:42 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 4ms (Views: 0.6ms | ActiveRecord: 0.4ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:44:46 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 4ms (Views: 0.4ms | ActiveRecord: 0.5ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:44:48 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 5ms (Views: 0.5ms | ActiveRecord: 0.6ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:49:21 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:49:21 +0800
+Completed 200 OK in 8ms (Views: 0.7ms | ActiveRecord: 0.6ms | Allocations: 1316)
+
+
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 9ms (Views: 0.7ms | ActiveRecord: 0.7ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:51:48 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:51:48 +0800
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 5ms (Views: 0.4ms | ActiveRecord: 1.1ms | Allocations: 1327)
+
+
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 8ms (Views: 0.6ms | ActiveRecord: 0.7ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:53:15 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:53:15 +0800
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 5ms (Views: 0.4ms | ActiveRecord: 0.5ms | Allocations: 1329)
+
+
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 7ms (Views: 0.8ms | ActiveRecord: 0.9ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:53:23 +0800
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:53:23 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+Processing by Api::V1::PostsController#show as */*
+  [1m[36mPost Load (1.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 12ms (Views: 0.5ms | ActiveRecord: 1.6ms | Allocations: 2345)
+
+
+  [1m[36mPost Load (0.8ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 30ms (Views: 0.4ms | ActiveRecord: 6.0ms | Allocations: 4698)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:53:42 +0800
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:53:42 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+Completed 200 OK in 7ms (Views: 0.4ms | ActiveRecord: 0.9ms | Allocations: 2053)
+
+
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 7ms (Views: 0.3ms | ActiveRecord: 1.1ms | Allocations: 2280)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:54:39 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:54:39 +0800
+  [1m[36mPost Load (1.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 7ms (Views: 0.4ms | ActiveRecord: 2.1ms | Allocations: 1369)
+
+
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.9ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 10ms (Views: 0.7ms | ActiveRecord: 1.3ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:54:48 +0800
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:54:48 +0800
+Processing by Api::V1::PostsController#show as */*
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 9ms (Views: 0.4ms | ActiveRecord: 1.3ms | Allocations: 1927)
+
+
+Completed 200 OK in 9ms (Views: 0.3ms | ActiveRecord: 1.0ms | Allocations: 2056)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:54:49 +0800
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:54:49 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (1.0ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (1.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 10ms (Views: 0.4ms | ActiveRecord: 2.0ms | Allocations: 2359)
+
+
+Completed 200 OK in 7ms (Views: 0.2ms | ActiveRecord: 0.6ms | Allocations: 2042)
+
+
+Started POST "/validate_token" for ::1 at 2024-01-01 18:54:53 +0800
+Started POST "/validate_token" for ::1 at 2024-01-01 18:54:53 +0800
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Processing by AuthenticationController#validate as HTML
+Completed 204 No Content in 1ms (ActiveRecord: 0.0ms | Allocations: 109)
+
+
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 1ms (ActiveRecord: 0.0ms | Allocations: 106)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 18:54:55 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.8ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 8ms (Views: 1.0ms | ActiveRecord: 1.2ms | Allocations: 1837)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 18:54:55 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 7ms (Views: 0.5ms | ActiveRecord: 1.3ms | Allocations: 1837)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:54:57 +0800
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:54:57 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+Processing by Api::V1::PostsController#show as */*
+  [1m[36mPost Load (1.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+  [1m[36mPost Load (0.8ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+Completed 200 OK in 7ms (Views: 0.8ms | ActiveRecord: 1.9ms | Allocations: 1589)
+
+
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 9ms (Views: 0.4ms | ActiveRecord: 1.2ms | Allocations: 1959)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:55:23 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 5ms (Views: 0.4ms | ActiveRecord: 0.7ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:55:30 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 6ms (Views: 0.5ms | ActiveRecord: 0.6ms | Allocations: 1042)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:55:30 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 6ms (Views: 0.6ms | ActiveRecord: 0.6ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:55:40 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 4ms (Views: 0.6ms | ActiveRecord: 0.4ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:55:58 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 4ms (Views: 0.4ms | ActiveRecord: 0.5ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 18:57:32 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 5ms (Views: 0.4ms | ActiveRecord: 0.5ms | Allocations: 1038)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 19:48:20 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 15ms (Views: 0.5ms | ActiveRecord: 4.7ms | Allocations: 3817)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 19:52:56 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 5ms (Views: 0.4ms | ActiveRecord: 0.6ms | Allocations: 1045)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 19:52:56 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 7ms (Views: 2.4ms | ActiveRecord: 0.7ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 19:53:05 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 4ms (Views: 0.4ms | ActiveRecord: 0.6ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 19:53:41 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 5ms (Views: 0.5ms | ActiveRecord: 0.8ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 19:54:19 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 4ms (Views: 0.4ms | ActiveRecord: 0.7ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 19:59:28 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 4ms (Views: 0.5ms | ActiveRecord: 0.4ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 19:59:43 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 4ms (Views: 0.4ms | ActiveRecord: 0.5ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 19:59:59 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 4ms (Views: 0.4ms | ActiveRecord: 0.3ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:00:57 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:00:57 +0800
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 6ms (Views: 0.4ms | ActiveRecord: 0.6ms | Allocations: 1329)
+
+
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 9ms (Views: 0.9ms | ActiveRecord: 0.6ms | Allocations: 1038)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:01:16 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 5ms (Views: 0.5ms | ActiveRecord: 0.4ms | Allocations: 1038)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:01:37 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 4ms (Views: 0.4ms | ActiveRecord: 0.4ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:01:52 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 5ms (Views: 0.4ms | ActiveRecord: 0.6ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:02:28 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 4ms (Views: 0.3ms | ActiveRecord: 0.4ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:02:36 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 5ms (Views: 0.4ms | ActiveRecord: 0.6ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:02:39 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:02:39 +0800
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 8ms (Views: 0.5ms | ActiveRecord: 1.1ms | Allocations: 1324)
+
+
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 6ms (Views: 0.6ms | ActiveRecord: 0.8ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:02:56 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 5ms (Views: 0.5ms | ActiveRecord: 0.5ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:03:22 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 4ms (Views: 0.3ms | ActiveRecord: 0.4ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:03:38 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 4ms (Views: 0.5ms | ActiveRecord: 0.4ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:04:14 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 4ms (Views: 0.6ms | ActiveRecord: 0.4ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:04:37 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 4ms (Views: 0.6ms | ActiveRecord: 0.4ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:06:23 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 4ms (Views: 0.5ms | ActiveRecord: 0.4ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:06:23 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 4ms (Views: 0.3ms | ActiveRecord: 0.4ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:06:33 +0800
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:06:33 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (1.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 7ms (Views: 0.7ms | ActiveRecord: 1.8ms | Allocations: 2367)
+
+
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 27ms (Views: 0.4ms | ActiveRecord: 10.0ms | Allocations: 5037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:06:50 +0800
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:06:50 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+Completed 200 OK in 6ms (Views: 0.6ms | ActiveRecord: 1.1ms | Allocations: 1673)
+
+
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 8ms (Views: 0.4ms | ActiveRecord: 1.0ms | Allocations: 2280)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:07:44 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 4ms (Views: 0.4ms | ActiveRecord: 0.3ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:08:12 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 5ms (Views: 0.6ms | ActiveRecord: 0.6ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:08:17 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 3ms (Views: 0.3ms | ActiveRecord: 0.4ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:08:22 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 4ms (Views: 0.4ms | ActiveRecord: 0.5ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:08:47 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 3ms (Views: 0.3ms | ActiveRecord: 0.3ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:09:49 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:09:49 +0800
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 7ms (Views: 0.6ms | ActiveRecord: 0.5ms | Allocations: 1329)
+
+
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 5ms (Views: 0.4ms | ActiveRecord: 0.7ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:09:55 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 3ms (Views: 0.3ms | ActiveRecord: 0.4ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:10:05 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 4ms (Views: 0.4ms | ActiveRecord: 0.4ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:10:40 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 4ms (Views: 0.3ms | ActiveRecord: 0.3ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:10:53 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:10:53 +0800
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 7ms (Views: 0.5ms | ActiveRecord: 0.7ms | Allocations: 1324)
+
+
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 5ms (Views: 0.5ms | ActiveRecord: 0.7ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:11:43 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:11:43 +0800
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 5ms (Views: 0.6ms | ActiveRecord: 0.6ms | Allocations: 1099)
+
+
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 8ms (Views: 0.6ms | ActiveRecord: 0.6ms | Allocations: 1038)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 20:11:43 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (1.1ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 10ms (Views: 0.9ms | ActiveRecord: 1.8ms | Allocations: 1837)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 20:11:43 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 8ms (Views: 0.7ms | ActiveRecord: 1.2ms | Allocations: 1837)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:13:27 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:13:27 +0800
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 12ms (Views: 5.9ms | ActiveRecord: 0.9ms | Allocations: 1332)
+
+
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 4ms (Views: 0.4ms | ActiveRecord: 0.4ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:14:01 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 5ms (Views: 0.4ms | ActiveRecord: 0.4ms | Allocations: 1037)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:14:03 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:14:03 +0800
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 7ms (Views: 0.5ms | ActiveRecord: 0.6ms | Allocations: 1324)
+
+
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 6ms (Views: 0.6ms | ActiveRecord: 0.7ms | Allocations: 1037)
+
+
+Started PATCH "/api/v1/update/7" for ::1 at 2024-01-01 20:14:20 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"edit", "category"=>"edited", "content"=>"hello I have edited content", "id"=>"7", "post"=>{"title"=>"edit", "content"=>"hello I have edited content", "category"=>"edited"}}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+[31mUnpermitted parameters: :token, :id, :post. Context: { controller: Api::V1::PostsController, action: update, request: #<ActionDispatch::Request:0x00007f3b20191380>, params: {"token"=>"[FILTERED]", "title"=>"edit", "category"=>"edited", "content"=>"hello I have edited content", "controller"=>"api/v1/posts", "action"=>"update", "id"=>"7", "post"=>{"title"=>"edit", "content"=>"hello I have edited content", "category"=>"edited"}} }[0m
+Completed 500 Internal Server Error in 3ms (ActiveRecord: 0.3ms | Allocations: 784)
+
+
+  
+NoMethodError (undefined method `update' for nil:NilClass):
+  
+app/controllers/api/v1/posts_controller.rb:56:in `update'
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:16:27 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 5ms (Views: 1.4ms | ActiveRecord: 0.5ms | Allocations: 1036)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:20:18 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 6ms (Views: 1.3ms | ActiveRecord: 0.6ms | Allocations: 1036)
+
+
+Started PATCH "/api/v1/update/7" for ::1 at 2024-01-01 20:20:26 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"sdsfd", "category"=>"sdfs", "content"=>"dfvbdf", "id"=>"7", "post"=>{"title"=>"sdsfd", "content"=>"dfvbdf", "category"=>"sdfs"}}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+[31mUnpermitted parameters: :token, :id, :post. Context: { controller: Api::V1::PostsController, action: update, request: #<ActionDispatch::Request:0x00007f3b20287dc0>, params: {"token"=>"[FILTERED]", "title"=>"sdsfd", "category"=>"sdfs", "content"=>"dfvbdf", "controller"=>"api/v1/posts", "action"=>"update", "id"=>"7", "post"=>{"title"=>"sdsfd", "content"=>"dfvbdf", "category"=>"sdfs"}} }[0m
+Completed 500 Internal Server Error in 4ms (ActiveRecord: 0.3ms | Allocations: 752)
+
+
+  
+NoMethodError (undefined method `update' for nil:NilClass):
+  
+app/controllers/api/v1/posts_controller.rb:56:in `update'
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:22:20 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 19ms (Views: 0.6ms | ActiveRecord: 9.3ms | Allocations: 7601)
+
+
+Started PATCH "/api/v1/update/7" for ::1 at 2024-01-01 20:22:23 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"dfgds", "category"=>"sds", "content"=>"sdfsdgsdfgs", "id"=>"7", "post"=>{"title"=>"dfgds", "content"=>"sdfsdgsdfgs", "category"=>"sds"}}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+[31mUnpermitted parameters: :token, :id, :post. Context: { controller: Api::V1::PostsController, action: update, request: #<ActionDispatch::Request:0x00007f3b201c3858>, params: {"token"=>"[FILTERED]", "title"=>"dfgds", "category"=>"sds", "content"=>"sdfsdgsdfgs", "controller"=>"api/v1/posts", "action"=>"update", "id"=>"7", "post"=>{"title"=>"dfgds", "content"=>"sdfsdgsdfgs", "category"=>"sds"}} }[0m
+Completed 500 Internal Server Error in 4ms (ActiveRecord: 0.3ms | Allocations: 763)
+
+
+  
+NoMethodError (undefined method `update' for nil:NilClass):
+  
+app/controllers/api/v1/posts_controller.rb:56:in `update'
+Started PATCH "/api/v1/update/7" for ::1 at 2024-01-01 20:28:51 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"dfgds", "category"=>"sds", "content"=>"sdfsdgsdfgs", "id"=>"7", "post"=>{"title"=>"dfgds", "content"=>"sdfsdgsdfgs", "category"=>"sds"}}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:130:in `authenticate_user'
+[31mUnpermitted parameters: :token, :id, :post. Context: { controller: Api::V1::PostsController, action: update, request: #<ActionDispatch::Request:0x00007f3b201c28b8>, params: {"token"=>"[FILTERED]", "title"=>"dfgds", "category"=>"sds", "content"=>"sdfsdgsdfgs", "controller"=>"api/v1/posts", "action"=>"update", "id"=>"7", "post"=>{"title"=>"dfgds", "content"=>"sdfsdgsdfgs", "category"=>"sds"}} }[0m
+[31mUnpermitted parameters: :token, :id, :post. Context: { controller: Api::V1::PostsController, action: update, request: #<ActionDispatch::Request:0x00007f3b201c28b8>, params: {"token"=>"[FILTERED]", "title"=>"dfgds", "category"=>"sds", "content"=>"sdfsdgsdfgs", "controller"=>"api/v1/posts", "action"=>"update", "id"=>"7", "post"=>{"title"=>"dfgds", "content"=>"sdfsdgsdfgs", "category"=>"sds"}} }[0m
+Completed 500 Internal Server Error in 11ms (ActiveRecord: 6.0ms | Allocations: 3943)
+
+
+  
+NoMethodError (undefined method `update' for nil:NilClass):
+  
+app/controllers/api/v1/posts_controller.rb:57:in `update'
+Started PATCH "/api/v1/update/7" for ::1 at 2024-01-01 20:31:52 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"dfgds", "category"=>"sds", "content"=>"sdfsdgsdfgs", "id"=>"7", "post"=>{"title"=>"dfgds", "content"=>"sdfsdgsdfgs", "category"=>"sds"}}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:130:in `authenticate_user'
+[31mUnpermitted parameters: :token, :id, :post. Context: { controller: Api::V1::PostsController, action: update, request: #<ActionDispatch::Request:0x00007f3b22f2c128>, params: {"token"=>"[FILTERED]", "title"=>"dfgds", "category"=>"sds", "content"=>"sdfsdgsdfgs", "controller"=>"api/v1/posts", "action"=>"update", "id"=>"7", "post"=>{"title"=>"dfgds", "content"=>"sdfsdgsdfgs", "category"=>"sds"}} }[0m
+Completed 500 Internal Server Error in 17ms (ActiveRecord: 8.6ms | Allocations: 3924)
+
+
+  
+TypeError (no implicit conversion of ActionController::Parameters into String):
+  
+app/controllers/api/v1/posts_controller.rb:56:in `+'
+app/controllers/api/v1/posts_controller.rb:56:in `update'
+Started PATCH "/api/v1/update/7" for ::1 at 2024-01-01 20:32:06 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"dfgds", "category"=>"sds", "content"=>"sdfsdgsdfgs", "id"=>"7", "post"=>{"title"=>"dfgds", "content"=>"sdfsdgsdfgs", "category"=>"sds"}}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+[31mUnpermitted parameters: :token, :id, :post. Context: { controller: Api::V1::PostsController, action: update, request: #<ActionDispatch::Request:0x00007f3b22f29568>, params: {"token"=>"[FILTERED]", "title"=>"dfgds", "category"=>"sds", "content"=>"sdfsdgsdfgs", "controller"=>"api/v1/posts", "action"=>"update", "id"=>"7", "post"=>{"title"=>"dfgds", "content"=>"sdfsdgsdfgs", "category"=>"sds"}} }[0m
+[31mUnpermitted parameters: :token, :id, :post. Context: { controller: Api::V1::PostsController, action: update, request: #<ActionDispatch::Request:0x00007f3b22f29568>, params: {"token"=>"[FILTERED]", "title"=>"dfgds", "category"=>"sds", "content"=>"sdfsdgsdfgs", "controller"=>"api/v1/posts", "action"=>"update", "id"=>"7", "post"=>{"title"=>"dfgds", "content"=>"sdfsdgsdfgs", "category"=>"sds"}} }[0m
+Completed 500 Internal Server Error in 18ms (ActiveRecord: 7.7ms | Allocations: 4088)
+
+
+  
+NoMethodError (undefined method `update' for nil:NilClass):
+  
+app/controllers/api/v1/posts_controller.rb:58:in `update'
+Started PATCH "/api/v1/update/7" for ::1 at 2024-01-01 20:33:47 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"dfgds", "category"=>"sds", "content"=>"sdfsdgsdfgs", "id"=>"7", "post"=>{"title"=>"dfgds", "content"=>"sdfsdgsdfgs", "category"=>"sds"}}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+[31mUnpermitted parameters: :token, :id, :post. Context: { controller: Api::V1::PostsController, action: update, request: #<ActionDispatch::Request:0x00007f3b22f1dd58>, params: {"token"=>"[FILTERED]", "title"=>"dfgds", "category"=>"sds", "content"=>"sdfsdgsdfgs", "controller"=>"api/v1/posts", "action"=>"update", "id"=>"7", "post"=>{"title"=>"dfgds", "content"=>"sdfsdgsdfgs", "category"=>"sds"}} }[0m
+Completed 500 Internal Server Error in 15ms (ActiveRecord: 6.9ms | Allocations: 3929)
+
+
+  
+NoMethodError (undefined method `update' for nil:NilClass):
+  
+app/controllers/api/v1/posts_controller.rb:59:in `update'
+Started PATCH "/api/v1/update/7" for ::1 at 2024-01-01 20:35:06 +0800
+  [1m[36mActiveRecord::SchemaMigration Load (1.1ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"dfgds", "category"=>"sds", "content"=>"sdfsdgsdfgs", "id"=>"7", "post"=>{"title"=>"dfgds", "content"=>"sdfsdgsdfgs", "category"=>"sds"}}
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+[31mUnpermitted parameters: :token, :id, :post. Context: { controller: Api::V1::PostsController, action: update, request: #<ActionDispatch::Request:0x00007f3f1db353e0>, params: {"token"=>"[FILTERED]", "title"=>"dfgds", "category"=>"sds", "content"=>"sdfsdgsdfgs", "controller"=>"api/v1/posts", "action"=>"update", "id"=>"7", "post"=>{"title"=>"dfgds", "content"=>"sdfsdgsdfgs", "category"=>"sds"}} }[0m
+Completed 500 Internal Server Error in 50ms (ActiveRecord: 13.5ms | Allocations: 13702)
+
+
+  
+NoMethodError (undefined method `update' for nil:NilClass):
+  
+app/controllers/api/v1/posts_controller.rb:59:in `update'
+Started PATCH "/api/v1/update/7" for ::1 at 2024-01-01 20:37:10 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"dfgds", "category"=>"sds", "content"=>"sdfsdgsdfgs", "id"=>"7", "post"=>{"title"=>"dfgds", "content"=>"sdfsdgsdfgs", "category"=>"sds"}}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+[31mUnpermitted parameters: :token, :id, :post. Context: { controller: Api::V1::PostsController, action: update, request: #<ActionDispatch::Request:0x00007f3f1dade068>, params: {"token"=>"[FILTERED]", "title"=>"dfgds", "category"=>"sds", "content"=>"sdfsdgsdfgs", "controller"=>"api/v1/posts", "action"=>"update", "id"=>"7", "post"=>{"title"=>"dfgds", "content"=>"sdfsdgsdfgs", "category"=>"sds"}} }[0m
+Completed 500 Internal Server Error in 13ms (ActiveRecord: 6.5ms | Allocations: 3930)
+
+
+  
+NoMethodError (undefined method `update' for nil:NilClass):
+  
+app/controllers/api/v1/posts_controller.rb:59:in `update'
+Started PATCH "/api/v1/update/7" for ::1 at 2024-01-01 20:38:07 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"dfgds", "category"=>"sds", "content"=>"sdfsdgsdfgs", "id"=>"7", "post"=>{"title"=>"dfgds", "content"=>"sdfsdgsdfgs", "category"=>"sds"}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:157:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+[31mUnpermitted parameters: :token, :id, :post. Context: { controller: Api::V1::PostsController, action: update, request: #<ActionDispatch::Request:0x00007f3f1d9e2308>, params: {"token"=>"[FILTERED]", "title"=>"dfgds", "category"=>"sds", "content"=>"sdfsdgsdfgs", "controller"=>"api/v1/posts", "action"=>"update", "id"=>"7", "post"=>{"title"=>"dfgds", "content"=>"sdfsdgsdfgs", "category"=>"sds"}} }[0m
+Completed 500 Internal Server Error in 42ms (ActiveRecord: 9.9ms | Allocations: 13231)
+
+
+  
+ActiveModel::ForbiddenAttributesError (ActiveModel::ForbiddenAttributesError):
+  
+app/controllers/api/v1/posts_controller.rb:59:in `update'
+Started PATCH "/api/v1/update/7" for ::1 at 2024-01-01 20:41:09 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"dfgds", "category"=>"sds", "content"=>"sdfsdgsdfgs", "id"=>"7", "post"=>{"title"=>"dfgds", "content"=>"sdfsdgsdfgs", "category"=>"sds"}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:158:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:133:in `authenticate_user'
+[31mUnpermitted parameters: :token, :id, :post. Context: { controller: Api::V1::PostsController, action: update, request: #<ActionDispatch::Request:0x00007f3f1fa9cee0>, params: {"token"=>"[FILTERED]", "title"=>"dfgds", "category"=>"sds", "content"=>"sdfsdgsdfgs", "controller"=>"api/v1/posts", "action"=>"update", "id"=>"7", "post"=>{"title"=>"dfgds", "content"=>"sdfsdgsdfgs", "category"=>"sds"}} }[0m
+Completed 500 Internal Server Error in 24ms (ActiveRecord: 9.9ms | Allocations: 7774)
+
+
+  
+ActiveModel::ForbiddenAttributesError (ActiveModel::ForbiddenAttributesError):
+  
+app/controllers/api/v1/posts_controller.rb:60:in `update'
+Started PATCH "/api/v1/update/7" for ::1 at 2024-01-01 20:42:36 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"dfgds", "category"=>"sds", "content"=>"sdfsdgsdfgs", "id"=>"7", "post"=>{"title"=>"dfgds", "content"=>"sdfsdgsdfgs", "category"=>"sds"}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:158:in `set_post'
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:133:in `authenticate_user'
+[31mUnpermitted parameters: :token, :id, :post. Context: { controller: Api::V1::PostsController, action: update, request: #<ActionDispatch::Request:0x00007f3f1d9c24e0>, params: {"token"=>"[FILTERED]", "title"=>"dfgds", "category"=>"sds", "content"=>"sdfsdgsdfgs", "controller"=>"api/v1/posts", "action"=>"update", "id"=>"7", "post"=>{"title"=>"dfgds", "content"=>"sdfsdgsdfgs", "category"=>"sds"}} }[0m
+Completed 500 Internal Server Error in 20ms (ActiveRecord: 6.9ms | Allocations: 7776)
+
+
+  
+ArgumentError (When assigning attributes, you must pass a hash as an argument, String passed.):
+  
+app/controllers/api/v1/posts_controller.rb:60:in `update'
+Started PATCH "/api/v1/update/7" for ::1 at 2024-01-01 20:43:32 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"dfgds", "category"=>"sds", "content"=>"sdfsdgsdfgs", "id"=>"7", "post"=>{"title"=>"dfgds", "content"=>"sdfsdgsdfgs", "category"=>"sds"}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:158:in `set_post'
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:133:in `authenticate_user'
+[31mUnpermitted parameters: :token, :id, :post. Context: { controller: Api::V1::PostsController, action: update, request: #<ActionDispatch::Request:0x00007f3f2059e398>, params: {"token"=>"[FILTERED]", "title"=>"dfgds", "category"=>"sds", "content"=>"sdfsdgsdfgs", "controller"=>"api/v1/posts", "action"=>"update", "id"=>"7", "post"=>{"title"=>"dfgds", "content"=>"sdfsdgsdfgs", "category"=>"sds"}} }[0m
+Completed 500 Internal Server Error in 18ms (ActiveRecord: 6.2ms | Allocations: 7771)
+
+
+  
+ActiveModel::ForbiddenAttributesError (ActiveModel::ForbiddenAttributesError):
+  
+app/controllers/api/v1/posts_controller.rb:60:in `update'
+Started PATCH "/api/v1/update/7" for ::1 at 2024-01-01 20:43:46 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"dfgds", "category"=>"sds", "content"=>"sdfsdgsdfgs", "id"=>"7", "post"=>{"title"=>"dfgds", "content"=>"sdfsdgsdfgs", "category"=>"sds"}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:158:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:133:in `authenticate_user'
+[31mUnpermitted parameters: :token, :id, :post. Context: { controller: Api::V1::PostsController, action: update, request: #<ActionDispatch::Request:0x00007f3f1d8b3a40>, params: {"token"=>"[FILTERED]", "title"=>"dfgds", "category"=>"sds", "content"=>"sdfsdgsdfgs", "controller"=>"api/v1/posts", "action"=>"update", "id"=>"7", "post"=>{"title"=>"dfgds", "content"=>"sdfsdgsdfgs", "category"=>"sds"}} }[0m
+Completed 500 Internal Server Error in 18ms (ActiveRecord: 5.8ms | Allocations: 7752)
+
+
+  
+ActiveModel::ForbiddenAttributesError (ActiveModel::ForbiddenAttributesError):
+  
+app/controllers/api/v1/posts_controller.rb:60:in `update'
+Started PATCH "/api/v1/update/7" for ::1 at 2024-01-01 20:46:25 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"dfgds", "category"=>"sds", "content"=>"sdfsdgsdfgs", "id"=>"7", "post"=>{"title"=>"dfgds", "content"=>"sdfsdgsdfgs", "category"=>"sds"}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:158:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:133:in `authenticate_user'
+[31mUnpermitted parameters: :token, :id, :post. Context: { controller: Api::V1::PostsController, action: update, request: #<ActionDispatch::Request:0x00007f3f1d8b2e60>, params: {"token"=>"[FILTERED]", "title"=>"dfgds", "category"=>"sds", "content"=>"sdfsdgsdfgs", "controller"=>"api/v1/posts", "action"=>"update", "id"=>"7", "post"=>{"title"=>"dfgds", "content"=>"sdfsdgsdfgs", "category"=>"sds"}} }[0m
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:60:in `update'
+  [1m[36mPost Update (1.9ms)[0m  [1m[33mUPDATE "posts" SET "title" = $1, "updated_at" = $2 WHERE "posts"."id" = $3[0m  [["title", "test"], ["updated_at", "2024-01-01 12:46:25.960061"], ["id", 7]]
+  ↳ app/controllers/api/v1/posts_controller.rb:60:in `update'
+  [1m[36mTRANSACTION (1.2ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:60:in `update'
+Completed 200 OK in 22ms (Views: 0.6ms | ActiveRecord: 9.8ms | Allocations: 10091)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:46:49 +0800
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:46:49 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:158:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:133:in `authenticate_user'
+Completed 200 OK in 26ms (Views: 0.4ms | ActiveRecord: 6.9ms | Allocations: 7563)
+
+
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:158:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:133:in `authenticate_user'
+Completed 200 OK in 25ms (Views: 0.7ms | ActiveRecord: 9.0ms | Allocations: 7542)
+
+
+Started PATCH "/api/v1/update/7" for ::1 at 2024-01-01 20:46:51 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"test", "category"=>"sds", "content"=>"sdfsdgsdfgs", "id"=>"7", "post"=>{"title"=>"test", "content"=>"sdfsdgsdfgs", "category"=>"sds"}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:158:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:133:in `authenticate_user'
+[31mUnpermitted parameters: :token, :id, :post. Context: { controller: Api::V1::PostsController, action: update, request: #<ActionDispatch::Request:0x00007f3f2056e3a0>, params: {"token"=>"[FILTERED]", "title"=>"test", "category"=>"sds", "content"=>"sdfsdgsdfgs", "controller"=>"api/v1/posts", "action"=>"update", "id"=>"7", "post"=>{"title"=>"test", "content"=>"sdfsdgsdfgs", "category"=>"sds"}} }[0m
+Completed 200 OK in 8ms (Views: 0.4ms | ActiveRecord: 0.5ms | Allocations: 1431)
+
+
+Started PATCH "/api/v1/update/7" for ::1 at 2024-01-01 20:47:00 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"sdfsgf", "category"=>"sds", "content"=>"sdfsdgsdfgs", "id"=>"7", "post"=>{"title"=>"sdfsgf", "content"=>"sdfsdgsdfgs", "category"=>"sds"}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:158:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:133:in `authenticate_user'
+[31mUnpermitted parameters: :token, :id, :post. Context: { controller: Api::V1::PostsController, action: update, request: #<ActionDispatch::Request:0x00007f3f2059c958>, params: {"token"=>"[FILTERED]", "title"=>"sdfsgf", "category"=>"sds", "content"=>"sdfsdgsdfgs", "controller"=>"api/v1/posts", "action"=>"update", "id"=>"7", "post"=>{"title"=>"sdfsgf", "content"=>"sdfsdgsdfgs", "category"=>"sds"}} }[0m
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:60:in `update'
+  [1m[36mPost Update (1.6ms)[0m  [1m[33mUPDATE "posts" SET "title" = $1, "updated_at" = $2 WHERE "posts"."id" = $3[0m  [["title", "sdfsgf"], ["updated_at", "2024-01-01 12:47:00.525864"], ["id", 7]]
+  ↳ app/controllers/api/v1/posts_controller.rb:60:in `update'
+  [1m[36mTRANSACTION (9.8ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:60:in `update'
+Completed 200 OK in 20ms (Views: 0.8ms | ActiveRecord: 11.9ms | Allocations: 2771)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 20:47:10 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (1.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 8ms (Views: 1.0ms | ActiveRecord: 1.8ms | Allocations: 1968)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 20:47:10 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 5ms (Views: 0.5ms | ActiveRecord: 0.9ms | Allocations: 1837)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:47:12 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:158:in `set_post'
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:47:12 +0800
+  ↳ app/controllers/api/v1/posts_controller.rb:133:in `authenticate_user'
+Completed 200 OK in 7ms (Views: 0.6ms | ActiveRecord: 0.9ms | Allocations: 1323)
+
+
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:158:in `set_post'
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:133:in `authenticate_user'
+Completed 200 OK in 7ms (Views: 0.5ms | ActiveRecord: 0.8ms | Allocations: 1037)
+
+
+Started PATCH "/api/v1/update/7" for ::1 at 2024-01-01 20:47:19 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"what happened", "category"=>"sds", "content"=>"sdfsdgsdfgs", "id"=>"7", "post"=>{"title"=>"what happened", "content"=>"sdfsdgsdfgs", "category"=>"sds"}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:158:in `set_post'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:133:in `authenticate_user'
+[31mUnpermitted parameters: :token, :id, :post. Context: { controller: Api::V1::PostsController, action: update, request: #<ActionDispatch::Request:0x00007f3f1da64880>, params: {"token"=>"[FILTERED]", "title"=>"what happened", "category"=>"sds", "content"=>"sdfsdgsdfgs", "controller"=>"api/v1/posts", "action"=>"update", "id"=>"7", "post"=>{"title"=>"what happened", "content"=>"sdfsdgsdfgs", "category"=>"sds"}} }[0m
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:60:in `update'
+  [1m[36mPost Update (1.7ms)[0m  [1m[33mUPDATE "posts" SET "title" = $1, "updated_at" = $2 WHERE "posts"."id" = $3[0m  [["title", "what happened"], ["updated_at", "2024-01-01 12:47:19.886879"], ["id", 7]]
+  ↳ app/controllers/api/v1/posts_controller.rb:60:in `update'
+  [1m[36mTRANSACTION (10.2ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:60:in `update'
+Completed 200 OK in 22ms (Views: 0.6ms | ActiveRecord: 12.7ms | Allocations: 2741)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 20:47:23 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 7ms (Views: 1.1ms | ActiveRecord: 1.1ms | Allocations: 1837)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 20:47:23 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 6ms (Views: 0.5ms | ActiveRecord: 0.9ms | Allocations: 1837)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:47:24 +0800
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:47:24 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+Processing by Api::V1::PostsController#show as */*
+  [1m[36mPost Load (1.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  ↳ app/controllers/api/v1/posts_controller.rb:158:in `set_post'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:133:in `authenticate_user'
+Completed 200 OK in 8ms (Views: 0.4ms | ActiveRecord: 1.5ms | Allocations: 2457)
+
+
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:158:in `set_post'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:133:in `authenticate_user'
+Completed 200 OK in 16ms (Views: 0.4ms | ActiveRecord: 5.0ms | Allocations: 4737)
+
+
+Started PATCH "/api/v1/update/7" for ::1 at 2024-01-01 20:47:44 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"what happened hi", "category"=>"sds", "content"=>"sdfsdgsdfgs", "id"=>"7", "post"=>{"title"=>"what happened hi", "content"=>"sdfsdgsdfgs", "category"=>"sds"}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:156:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:58:in `update'
+  [1m[36mPost Update (1.5ms)[0m  [1m[33mUPDATE "posts" SET "title" = $1, "updated_at" = $2 WHERE "posts"."id" = $3[0m  [["title", "what happened hi"], ["updated_at", "2024-01-01 12:47:44.483763"], ["id", 7]]
+  ↳ app/controllers/api/v1/posts_controller.rb:58:in `update'
+  [1m[36mTRANSACTION (1.6ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:58:in `update'
+Completed 200 OK in 33ms (Views: 0.7ms | ActiveRecord: 15.4ms | Allocations: 9307)
+
+
+Started PATCH "/api/v1/update/7" for ::1 at 2024-01-01 20:48:14 +0800
+  
+SyntaxError (/home/pengxuan/CVWO/CVWO_backend/app/controllers/api/v1/posts_controller.rb:58: syntax error, unexpected ')', expecting =>
+...[:category], content[:content])
+...                              ^
+):
+  
+app/controllers/api/v1/posts_controller.rb:58: syntax error, unexpected ')', expecting =>
+Started PATCH "/api/v1/update/7" for ::1 at 2024-01-01 20:48:29 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"what happened hi", "category"=>"sds", "content"=>"sdfsdgsdfgs", "id"=>"7", "post"=>{"title"=>"what happened hi", "content"=>"sdfsdgsdfgs", "category"=>"sds"}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:156:in `set_post'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+Completed 500 Internal Server Error in 22ms (ActiveRecord: 7.9ms | Allocations: 7507)
+
+
+  
+NameError (undefined local variable or method `content' for #<Api::V1::PostsController:0x000000000355e8>):
+  
+app/controllers/api/v1/posts_controller.rb:58:in `update'
+Started PATCH "/api/v1/update/7" for ::1 at 2024-01-01 20:48:51 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"what happened hi", "category"=>"sds", "content"=>"sdfsdgsdfgs", "id"=>"7", "post"=>{"title"=>"what happened hi", "content"=>"sdfsdgsdfgs", "category"=>"sds"}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:156:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+Completed 200 OK in 17ms (Views: 0.4ms | ActiveRecord: 5.9ms | Allocations: 7813)
+
+
+Started PATCH "/api/v1/update/7" for ::1 at 2024-01-01 20:48:55 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"what happened hi", "category"=>"sds", "content"=>"sdfsdgsdfgs", "id"=>"7", "post"=>{"title"=>"what happened hi", "content"=>"sdfsdgsdfgs", "category"=>"sds"}}
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:156:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+Completed 200 OK in 5ms (Views: 0.3ms | ActiveRecord: 0.9ms | Allocations: 1150)
+
+
+Started PATCH "/api/v1/update/7" for ::1 at 2024-01-01 20:48:59 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"what happened hi", "category"=>"sds what", "content"=>"sdfsdgsdfgs", "id"=>"7", "post"=>{"title"=>"what happened hi", "content"=>"sdfsdgsdfgs", "category"=>"sds what"}}
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:156:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:58:in `update'
+  [1m[36mPost Update (2.0ms)[0m  [1m[33mUPDATE "posts" SET "category" = $1, "updated_at" = $2 WHERE "posts"."id" = $3[0m  [["category", "sds what"], ["updated_at", "2024-01-01 12:48:59.767447"], ["id", 7]]
+  ↳ app/controllers/api/v1/posts_controller.rb:58:in `update'
+  [1m[36mTRANSACTION (9.3ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:58:in `update'
+Completed 200 OK in 20ms (Views: 0.8ms | ActiveRecord: 12.2ms | Allocations: 2630)
+
+
+Started PATCH "/api/v1/update/7" for ::1 at 2024-01-01 20:49:07 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"what happened hi", "category"=>"sds what", "content"=>"nothing here", "id"=>"7", "post"=>{"title"=>"what happened hi", "content"=>"nothing here", "category"=>"sds what"}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:156:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:58:in `update'
+  [1m[36mPost Update (1.9ms)[0m  [1m[33mUPDATE "posts" SET "content" = $1, "updated_at" = $2 WHERE "posts"."id" = $3[0m  [["content", "nothing here"], ["updated_at", "2024-01-01 12:49:07.160415"], ["id", 7]]
+  ↳ app/controllers/api/v1/posts_controller.rb:58:in `update'
+  [1m[36mTRANSACTION (10.4ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:58:in `update'
+Completed 200 OK in 22ms (Views: 0.5ms | ActiveRecord: 12.8ms | Allocations: 2600)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 20:49:08 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.8ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 8ms (Views: 1.8ms | ActiveRecord: 1.2ms | Allocations: 1885)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 20:49:08 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.8ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 8ms (Views: 0.6ms | ActiveRecord: 1.4ms | Allocations: 1838)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:49:12 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:156:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+Completed 200 OK in 5ms (Views: 0.6ms | ActiveRecord: 0.5ms | Allocations: 1043)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 20:49:12 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:156:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+Completed 200 OK in 4ms (Views: 0.4ms | ActiveRecord: 0.5ms | Allocations: 1038)
+
+
+Started POST "/validate_token" for ::1 at 2024-01-01 20:49:24 +0800
+Started POST "/validate_token" for ::1 at 2024-01-01 20:49:24 +0800
+Processing by AuthenticationController#validate as HTML
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 1ms (ActiveRecord: 0.0ms | Allocations: 167)
+
+
+Completed 204 No Content in 1ms (ActiveRecord: 0.0ms | Allocations: 106)
+
+
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 20:49:29 +0800
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"test1", "category"=>"test", "content"=>"sdgdfdsfs", "post"=>{"title"=>"test1", "content"=>"sdgdfdsfs", "category"=>"test"}}
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+[31mUnpermitted parameters: :token, :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007f3f1d8b6880>, params: {"token"=>"[FILTERED]", "title"=>"test1", "category"=>"test", "content"=>"sdgdfdsfs", "controller"=>"api/v1/posts", "action"=>"create", "post"=>{"title"=>"test1", "content"=>"sdgdfdsfs", "category"=>"test"}} }[0m
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:46:in `create'
+  [1m[36mTRANSACTION (0.6ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:46:in `create'
+  [1m[36mPost Create (3.3ms)[0m  [1m[32mINSERT INTO "posts" ("user_id", "title", "content", "category", "like_count", "dislike_count", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING "id"[0m  [["user_id", 1], ["title", "test1"], ["content", "sdgdfdsfs"], ["category", "test"], ["like_count", 0], ["dislike_count", 0], ["created_at", "2024-01-01 12:49:29.735094"], ["updated_at", "2024-01-01 12:49:29.735094"]]
+  ↳ app/controllers/api/v1/posts_controller.rb:46:in `create'
+  [1m[36mTRANSACTION (1.5ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:46:in `create'
+Completed 200 OK in 31ms (Views: 0.7ms | ActiveRecord: 11.3ms | Allocations: 11048)
+
+
+Started POST "/api/v1/show/8" for ::1 at 2024-01-01 20:49:29 +0800
+Started POST "/api/v1/show/8" for ::1 at 2024-01-01 20:49:29 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"8", "post"=>{}}
+Processing by Api::V1::PostsController#show as */*
+  [1m[36mPost Load (1.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 8], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  Parameters: {"token"=>"[FILTERED]", "id"=>"8", "post"=>{}}
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 8], ["LIMIT", 1]]
+Completed 200 OK in 8ms (Views: 0.4ms | ActiveRecord: 2.0ms | Allocations: 1695)
+
+
+  ↳ app/controllers/api/v1/posts_controller.rb:154:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+Completed 200 OK in 6ms (Views: 0.5ms | ActiveRecord: 0.8ms | Allocations: 1771)
+
+
+Started POST "/validate_token" for ::1 at 2024-01-01 20:52:32 +0800
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 1ms (ActiveRecord: 0.0ms | Allocations: 112)
+
+
+Started POST "/validate_token" for ::1 at 2024-01-01 20:52:32 +0800
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 1ms (ActiveRecord: 0.0ms | Allocations: 105)
+
+
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 20:52:36 +0800
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "post"=>{"title"=>"fgd", "category"=>"dgd", "content"=>"dgddghd"}}
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+[31mUnpermitted parameters: :token, :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007f3f205a0c88>, params: {"token"=>"[FILTERED]", "post"=>{"title"=>"fgd", "category"=>"dgd", "content"=>"dgddghd"}, "controller"=>"api/v1/posts", "action"=>"create"} }[0m
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:46:in `create'
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:46:in `create'
+  [1m[36mPost Create (2.3ms)[0m  [1m[32mINSERT INTO "posts" ("user_id", "title", "content", "category", "like_count", "dislike_count", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING "id"[0m  [["user_id", 1], ["title", nil], ["content", nil], ["category", nil], ["like_count", 0], ["dislike_count", 0], ["created_at", "2024-01-01 12:52:36.838491"], ["updated_at", "2024-01-01 12:52:36.838491"]]
+  ↳ app/controllers/api/v1/posts_controller.rb:46:in `create'
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[31mROLLBACK[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:46:in `create'
+Completed 500 Internal Server Error in 10ms (ActiveRecord: 2.8ms | Allocations: 3120)
+
+
+  
+ActiveRecord::NotNullViolation (PG::NotNullViolation: ERROR:  null value in column "title" of relation "posts" violates not-null constraint
+DETAIL:  Failing row contains (9, 1, null, null, null, 0, 0, 2024-01-01 12:52:36.838491, 2024-01-01 12:52:36.838491).
+):
+  
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 21:19:49 +0800
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "post"=>{"title"=>"fgd", "category"=>"dgd", "content"=>"dgddghd"}}
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:129:in `authenticate_user'
+[31mUnpermitted parameters: :token, :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007f3f1da4e1c0>, params: {"token"=>"[FILTERED]", "post"=>{"title"=>"fgd", "category"=>"dgd", "content"=>"dgddghd"}, "controller"=>"api/v1/posts", "action"=>"create"} }[0m
+Completed 422 Unprocessable Entity in 35ms (ActiveRecord: 5.5ms | Allocations: 11315)
+
+
+  
+ActiveRecord::RecordInvalid (Validation failed: User must exist):
+  
+app/controllers/api/v1/posts_controller.rb:46:in `create'
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 21:20:19 +0800
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "post"=>{"title"=>"fgd", "category"=>"dgd", "content"=>"dgddghd"}}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:130:in `authenticate_user'
+[31mUnpermitted parameters: :token, :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007f3f1d6bcb38>, params: {"token"=>"[FILTERED]", "post"=>{"title"=>"fgd", "category"=>"dgd", "content"=>"dgddghd"}, "controller"=>"api/v1/posts", "action"=>"create"} }[0m
+[31mUnpermitted parameters: :token, :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007f3f1d6bcb38>, params: {"token"=>"[FILTERED]", "post"=>{"title"=>"fgd", "category"=>"dgd", "content"=>"dgddghd"}, "controller"=>"api/v1/posts", "action"=>"create"} }[0m
+Completed 422 Unprocessable Entity in 36ms (ActiveRecord: 11.5ms | Allocations: 8354)
+
+
+  
+ActiveRecord::RecordInvalid (Validation failed: User must exist):
+  
+app/controllers/api/v1/posts_controller.rb:47:in `create'
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 21:21:28 +0800
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "post"=>{"title"=>"fgd", "category"=>"dgd", "content"=>"dgddghd"}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007f3f1d6df7a0>, params: {"token"=>"[FILTERED]", "post"=>{"title"=>"fgd", "category"=>"dgd", "content"=>"dgddghd"}, "controller"=>"api/v1/posts", "action"=>"create"} }[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+[31mUnpermitted parameters: :token, :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007f3f1d6df7a0>, params: {"token"=>"[FILTERED]", "post"=>{"title"=>"fgd", "category"=>"dgd", "content"=>"dgddghd"}, "controller"=>"api/v1/posts", "action"=>"create"} }[0m
+[31mUnpermitted parameters: :token, :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007f3f1d6df7a0>, params: {"token"=>"[FILTERED]", "post"=>{"title"=>"fgd", "category"=>"dgd", "content"=>"dgddghd"}, "controller"=>"api/v1/posts", "action"=>"create"} }[0m
+Completed 422 Unprocessable Entity in 21ms (ActiveRecord: 6.7ms | Allocations: 8441)
+
+
+  
+ActiveRecord::RecordInvalid (Validation failed: User must exist):
+  
+app/controllers/api/v1/posts_controller.rb:47:in `create'
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 21:27:11 +0800
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "post"=>{"title"=>"fgd", "category"=>"dgd", "content"=>"dgddghd"}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007f3f2189f5a0>, params: {"token"=>"[FILTERED]", "post"=>{"title"=>"fgd", "category"=>"dgd", "content"=>"dgddghd"}, "controller"=>"api/v1/posts", "action"=>"create"} }[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+Completed 422 Unprocessable Entity in 39ms (ActiveRecord: 5.9ms | Allocations: 10526)
+
+
+  
+ActiveRecord::RecordInvalid (Validation failed: User must exist):
+  
+app/controllers/api/v1/posts_controller.rb:47:in `create'
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 21:28:43 +0800
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "post"=>{"title"=>"fgd", "category"=>"dgd", "content"=>"dgddghd"}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007f3f1d6d5340>, params: {"token"=>"[FILTERED]", "post"=>{"title"=>"fgd", "category"=>"dgd", "content"=>"dgddghd"}, "controller"=>"api/v1/posts", "action"=>"create"} }[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+[31mUnpermitted parameters: :token, :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007f3f1d6d5340>, params: {"token"=>"[FILTERED]", "post"=>{"title"=>"fgd", "category"=>"dgd", "content"=>"dgddghd"}, "controller"=>"api/v1/posts", "action"=>"create"} }[0m
+[31mUnpermitted parameters: :token, :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007f3f1d6d5340>, params: {"token"=>"[FILTERED]", "post"=>{"title"=>"fgd", "category"=>"dgd", "content"=>"dgddghd"}, "controller"=>"api/v1/posts", "action"=>"create"} }[0m
+Completed 422 Unprocessable Entity in 32ms (ActiveRecord: 13.0ms | Allocations: 8477)
+
+
+  
+ActiveRecord::RecordInvalid (Validation failed: User must exist):
+  
+app/controllers/api/v1/posts_controller.rb:47:in `create'
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 21:28:52 +0800
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "post"=>{"title"=>"fgd", "category"=>"dgd", "content"=>"dgddghd"}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007f3f1d9687b0>, params: {"token"=>"[FILTERED]", "post"=>{"title"=>"fgd", "category"=>"dgd", "content"=>"dgddghd"}, "controller"=>"api/v1/posts", "action"=>"create"} }[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+[31mUnpermitted parameters: :token, :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007f3f1d9687b0>, params: {"token"=>"[FILTERED]", "post"=>{"title"=>"fgd", "category"=>"dgd", "content"=>"dgddghd"}, "controller"=>"api/v1/posts", "action"=>"create"} }[0m
+[31mUnpermitted parameters: :token, :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007f3f1d9687b0>, params: {"token"=>"[FILTERED]", "post"=>{"title"=>"fgd", "category"=>"dgd", "content"=>"dgddghd"}, "controller"=>"api/v1/posts", "action"=>"create"} }[0m
+  [1m[36mCACHE User Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mPost Create (1.7ms)[0m  [1m[32mINSERT INTO "posts" ("user_id", "title", "content", "category", "like_count", "dislike_count", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING "id"[0m  [["user_id", 1], ["title", nil], ["content", nil], ["category", nil], ["like_count", 0], ["dislike_count", 0], ["created_at", "2024-01-01 13:28:52.161349"], ["updated_at", "2024-01-01 13:28:52.161349"]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[31mROLLBACK[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+Completed 500 Internal Server Error in 40ms (ActiveRecord: 9.8ms | Allocations: 10723)
+
+
+  
+ActiveRecord::NotNullViolation (PG::NotNullViolation: ERROR:  null value in column "title" of relation "posts" violates not-null constraint
+DETAIL:  Failing row contains (10, 1, null, null, null, 0, 0, 2024-01-01 13:28:52.161349, 2024-01-01 13:28:52.161349).
+):
+  
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 21:32:17 +0800
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "post"=>{"title"=>"fgd", "category"=>"dgd", "content"=>"dgddghd"}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007f3f20530d20>, params: {"token"=>"[FILTERED]", "post"=>{"title"=>"fgd", "category"=>"dgd", "content"=>"dgddghd"}, "controller"=>"api/v1/posts", "action"=>"create"} }[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mPost Create (2.1ms)[0m  [1m[32mINSERT INTO "posts" ("user_id", "title", "content", "category", "like_count", "dislike_count", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING "id"[0m  [["user_id", 1], ["title", "fgd"], ["content", "dgddghd"], ["category", "dgd"], ["like_count", 0], ["dislike_count", 0], ["created_at", "2024-01-01 13:32:17.713856"], ["updated_at", "2024-01-01 13:32:17.713856"]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (1.6ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+Completed 200 OK in 36ms (Views: 0.6ms | ActiveRecord: 14.3ms | Allocations: 10495)
+
+
+Started POST "/api/v1/show/11" for ::1 at 2024-01-01 21:32:17 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"11", "post"=>{}}
+Started POST "/api/v1/show/11" for ::1 at 2024-01-01 21:32:17 +0800
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 11], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f3f1d9c9ba0>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"11", "post"=>{}} }[0m
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+Completed 200 OK in 8ms (Views: 0.9ms | ActiveRecord: 0.8ms | Allocations: 1778)
+
+
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"11", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 11], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f3f1d9e7da8>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"11", "post"=>{}} }[0m
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+Completed 200 OK in 6ms (Views: 0.5ms | ActiveRecord: 0.8ms | Allocations: 1142)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 21:33:57 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (1.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 13ms (Views: 2.6ms | ActiveRecord: 1.7ms | Allocations: 2614)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 21:33:57 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 15ms (Views: 0.9ms | ActiveRecord: 1.3ms | Allocations: 2568)
+
+
+Started POST "/validate_token" for ::1 at 2024-01-01 21:34:00 +0800
+Started POST "/validate_token" for ::1 at 2024-01-01 21:34:00 +0800
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 1ms (ActiveRecord: 0.0ms | Allocations: 147)
+
+
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 1ms (ActiveRecord: 0.0ms | Allocations: 105)
+
+
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 21:34:04 +0800
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "post"=>{"title"=>"what", "category"=>"sds", "content"=>"fgdgd"}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007f3f1f771f40>, params: {"token"=>"[FILTERED]", "post"=>{"title"=>"what", "category"=>"sds", "content"=>"fgdgd"}, "controller"=>"api/v1/posts", "action"=>"create"} }[0m
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (0.4ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mPost Create (2.7ms)[0m  [1m[32mINSERT INTO "posts" ("user_id", "title", "content", "category", "like_count", "dislike_count", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING "id"[0m  [["user_id", 1], ["title", "what"], ["content", "fgdgd"], ["category", "sds"], ["like_count", 0], ["dislike_count", 0], ["created_at", "2024-01-01 13:34:04.993698"], ["updated_at", "2024-01-01 13:34:04.993698"]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (1.0ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+Completed 200 OK in 15ms (Views: 0.4ms | ActiveRecord: 4.5ms | Allocations: 3072)
+
+
+Started POST "/api/v1/show/12" for ::1 at 2024-01-01 21:34:05 +0800
+Started POST "/api/v1/show/12" for ::1 at 2024-01-01 21:34:05 +0800
+Processing by Api::V1::PostsController#show as */*
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"12", "post"=>{}}
+  Parameters: {"token"=>"[FILTERED]", "id"=>"12", "post"=>{}}
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 12], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f3f21ac1cc0>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"12", "post"=>{}} }[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+Completed 200 OK in 6ms (Views: 0.6ms | ActiveRecord: 0.8ms | Allocations: 2159)
+
+
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 12], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f3f21ac0be0>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"12", "post"=>{}} }[0m
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+Completed 200 OK in 21ms (Views: 0.5ms | ActiveRecord: 8.1ms | Allocations: 5283)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 21:34:06 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (1.0ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 13ms (Views: 1.4ms | ActiveRecord: 1.7ms | Allocations: 2933)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 21:34:06 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 11ms (Views: 3.3ms | ActiveRecord: 1.2ms | Allocations: 2934)
+
+
+Started POST "/api/v1/show/12" for ::1 at 2024-01-01 21:34:10 +0800
+Started POST "/api/v1/show/12" for ::1 at 2024-01-01 21:34:10 +0800
+Processing by Api::V1::PostsController#show as */*
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"12", "post"=>{}}
+  Parameters: {"token"=>"[FILTERED]", "id"=>"12", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 12], ["LIMIT", 1]]
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 12], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+  ↳ app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f3f1d984398>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"12", "post"=>{}} }[0m
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f3f1d984b18>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"12", "post"=>{}} }[0m
+  [1m[36mUser Load (1.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+Completed 200 OK in 16ms (Views: 0.8ms | ActiveRecord: 1.3ms | Allocations: 2110)
+
+
+Completed 200 OK in 18ms (Views: 0.3ms | ActiveRecord: 1.2ms | Allocations: 2319)
+
+
+Started DELETE "/api/v1/destroy/12" for ::1 at 2024-01-01 21:34:11 +0800
+Processing by Api::V1::PostsController#destroy as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"12", "post"=>{}}
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 12], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: destroy, request: #<ActionDispatch::Request:0x00007f3f20581f40>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"destroy", "id"=>"12", "post"=>{}} }[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mPost Destroy (1.2ms)[0m  [1m[31mDELETE FROM "posts" WHERE "posts"."id" = $1[0m  [["id", 12]]
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mTRANSACTION (10.7ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+Completed 200 OK in 19ms (Views: 0.4ms | ActiveRecord: 12.6ms | Allocations: 2356)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 21:34:11 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 7ms (Views: 0.7ms | ActiveRecord: 0.9ms | Allocations: 2568)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 21:34:11 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 8ms (Views: 1.0ms | ActiveRecord: 1.1ms | Allocations: 2568)
+
+
+Started POST "/validate_token" for ::1 at 2024-01-01 21:34:14 +0800
+Started POST "/validate_token" for ::1 at 2024-01-01 21:34:14 +0800
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 1ms (ActiveRecord: 0.0ms | Allocations: 107)
+
+
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 1ms (ActiveRecord: 0.0ms | Allocations: 105)
+
+
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 21:34:20 +0800
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "post"=>{"title"=>"what", "category"=>"sgd", "content"=>"sfdgsdgf"}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007f3f20533660>, params: {"token"=>"[FILTERED]", "post"=>{"title"=>"what", "category"=>"sgd", "content"=>"sfdgsdgf"}, "controller"=>"api/v1/posts", "action"=>"create"} }[0m
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+  [1m[36mCACHE User Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (0.4ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mPost Create (2.7ms)[0m  [1m[32mINSERT INTO "posts" ("user_id", "title", "content", "category", "like_count", "dislike_count", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING "id"[0m  [["user_id", 1], ["title", "what"], ["content", "sfdgsdgf"], ["category", "sgd"], ["like_count", 0], ["dislike_count", 0], ["created_at", "2024-01-01 13:34:20.035606"], ["updated_at", "2024-01-01 13:34:20.035606"]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (1.2ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+Completed 200 OK in 20ms (Views: 0.7ms | ActiveRecord: 4.7ms | Allocations: 3073)
+
+
+Started POST "/api/v1/show/13" for ::1 at 2024-01-01 21:34:20 +0800
+Started POST "/api/v1/show/13" for ::1 at 2024-01-01 21:34:20 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"13", "post"=>{}}
+Processing by Api::V1::PostsController#show as */*
+  [1m[36mPost Load (1.1ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 13], ["LIMIT", 1]]
+  Parameters: {"token"=>"[FILTERED]", "id"=>"13", "post"=>{}}
+  ↳ app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f3f1d8fd988>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"13", "post"=>{}} }[0m
+  [1m[36mPost Load (1.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 13], ["LIMIT", 1]]
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f3f1d8fad28>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"13", "post"=>{}} }[0m
+Completed 200 OK in 8ms (Views: 0.6ms | ActiveRecord: 1.5ms | Allocations: 2029)
+
+
+  [1m[36mUser Load (1.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+Completed 200 OK in 10ms (Views: 0.7ms | ActiveRecord: 2.4ms | Allocations: 2168)
+
+
+Started POST "/validate_token" for ::1 at 2024-01-01 21:35:42 +0800
+Started POST "/validate_token" for ::1 at 2024-01-01 21:35:42 +0800
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 1ms (ActiveRecord: 0.0ms | Allocations: 153)
+
+
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 1ms (ActiveRecord: 0.0ms | Allocations: 153)
+
+
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 21:36:02 +0800
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "thread"=>{"title"=>"how", "category"=>"sdfa", "content"=>"dsfgsd"}, "post"=>{}}
+[31mUnpermitted parameters: :thread, :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007f3f1d53d3e8>, params: {"token"=>"[FILTERED]", "thread"=>{"title"=>"how", "category"=>"sdfa", "content"=>"dsfgsd"}, "controller"=>"api/v1/posts", "action"=>"create", "post"=>{}} }[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mPost Create (2.3ms)[0m  [1m[32mINSERT INTO "posts" ("user_id", "title", "content", "category", "like_count", "dislike_count", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING "id"[0m  [["user_id", 1], ["title", "how"], ["content", "dsfgsd"], ["category", "sdfa"], ["like_count", 0], ["dislike_count", 0], ["created_at", "2024-01-01 13:36:02.233439"], ["updated_at", "2024-01-01 13:36:02.233439"]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (1.1ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+Completed 200 OK in 29ms (Views: 0.5ms | ActiveRecord: 13.4ms | Allocations: 9891)
+
+
+Started POST "/api/v1/show/14" for ::1 at 2024-01-01 21:36:02 +0800
+Started POST "/api/v1/show/14" for ::1 at 2024-01-01 21:36:02 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"14", "post"=>{}}
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"14", "post"=>{}}
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 14], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+  [1m[36mPost Load (1.1ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 14], ["LIMIT", 1]]
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f3f1d7d91b0>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"14", "post"=>{}} }[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f3f1d7d8530>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"14", "post"=>{}} }[0m
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+Completed 200 OK in 11ms (Views: 0.4ms | ActiveRecord: 1.1ms | Allocations: 2082)
+
+
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+Completed 200 OK in 9ms (Views: 0.4ms | ActiveRecord: 1.6ms | Allocations: 2504)
+
+
+Started POST "/validate_token" for ::1 at 2024-01-01 21:40:37 +0800
+Started POST "/validate_token" for ::1 at 2024-01-01 21:40:37 +0800
+  [1m[36mActiveRecord::SchemaMigration Load (1.3ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+Processing by AuthenticationController#validate as HTML
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 9ms (ActiveRecord: 0.0ms | Allocations: 2716)
+
+
+Completed 204 No Content in 9ms (ActiveRecord: 0.0ms | Allocations: 2541)
+
+
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 21:40:41 +0800
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "thread"=>{"title"=>"test", "category"=>"sdgfds", "content"=>"dsgfdsgfsd"}, "post"=>{}}
+[31mUnpermitted parameters: :thread, :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007fd4ec1d7130>, params: {"token"=>"[FILTERED]", "thread"=>{"title"=>"test", "category"=>"sdgfds", "content"=>"dsgfdsgfsd"}, "controller"=>"api/v1/posts", "action"=>"create", "post"=>{}} }[0m
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+  [1m[36mCACHE User Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (0.4ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mPost Create (69.3ms)[0m  [1m[32mINSERT INTO "posts" ("user_id", "title", "content", "category", "like_count", "dislike_count", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING "id"[0m  [["user_id", 1], ["title", "test"], ["content", "dsgfdsgfsd"], ["category", "sdgfds"], ["like_count", 0], ["dislike_count", 0], ["created_at", "2024-01-01 13:40:41.509460"], ["updated_at", "2024-01-01 13:40:41.509460"]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (2.4ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+Completed 200 OK in 195ms (Views: 0.8ms | ActiveRecord: 86.4ms | Allocations: 24419)
+
+
+Started POST "/api/v1/show/15" for ::1 at 2024-01-01 21:40:41 +0800
+Started POST "/api/v1/show/15" for ::1 at 2024-01-01 21:40:41 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"15", "post"=>{}}
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"15", "post"=>{}}
+  [1m[36mPost Load (1.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 15], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007fd4ec02ad28>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"15", "post"=>{}} }[0m
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+Completed 200 OK in 11ms (Views: 0.4ms | ActiveRecord: 2.4ms | Allocations: 2884)
+
+
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 15], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007fd4ec0232a8>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"15", "post"=>{}} }[0m
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+Completed 200 OK in 18ms (Views: 0.5ms | ActiveRecord: 5.7ms | Allocations: 5304)
+
+
+Started POST "/validate_token" for ::1 at 2024-01-01 21:44:53 +0800
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 1ms (ActiveRecord: 0.0ms | Allocations: 107)
+
+
+Started POST "/validate_token" for ::1 at 2024-01-01 21:44:53 +0800
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 0ms (ActiveRecord: 0.0ms | Allocations: 105)
+
+
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 21:53:33 +0800
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "thread"=>{"title"=>"whag", "category"=>"sfda", "content"=>"sagsdfdsfdsgfsdg"}, "post"=>{}}
+[31mUnpermitted parameters: :thread, :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007fd4ecf67a98>, params: {"token"=>"[FILTERED]", "thread"=>{"title"=>"whag", "category"=>"sfda", "content"=>"sagsdfdsfdsgfsdg"}, "controller"=>"api/v1/posts", "action"=>"create", "post"=>{}} }[0m
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mPost Create (2.8ms)[0m  [1m[32mINSERT INTO "posts" ("user_id", "title", "content", "category", "like_count", "dislike_count", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING "id"[0m  [["user_id", 1], ["title", "whag"], ["content", "sagsdfdsfdsgfsdg"], ["category", "sfda"], ["like_count", 0], ["dislike_count", 0], ["created_at", "2024-01-01 13:53:33.279773"], ["updated_at", "2024-01-01 13:53:33.279773"]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (1.2ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+Completed 200 OK in 29ms (Views: 0.6ms | ActiveRecord: 8.3ms | Allocations: 9737)
+
+
+Started POST "/api/v1/show/16" for ::1 at 2024-01-01 21:53:33 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"16", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 16], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007fd4ecf15b58>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"16", "post"=>{}} }[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+Completed 200 OK in 7ms (Views: 1.0ms | ActiveRecord: 0.5ms | Allocations: 1370)
+
+
+Started POST "/api/v1/show/16" for ::1 at 2024-01-01 21:53:33 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"16", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 16], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007fd4eced8348>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"16", "post"=>{}} }[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+Completed 200 OK in 4ms (Views: 0.5ms | ActiveRecord: 0.5ms | Allocations: 1143)
+
+
+Started PATCH "/api/v1/update/16" for ::1 at 2024-01-01 21:55:30 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"whag", "category"=>"nh", "content"=>"sagsdfdsfdsgfsdg", "id"=>"16", "post"=>{"title"=>"whag", "content"=>"sagsdfdsfdsgfsdg", "category"=>"nh"}}
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 16], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+[31mUnpermitted parameters: :title, :category, :content, :id, :post. Context: { controller: Api::V1::PostsController, action: update, request: #<ActionDispatch::Request:0x00007fd4ece9aca0>, params: {"token"=>"[FILTERED]", "title"=>"whag", "category"=>"nh", "content"=>"sagsdfdsfdsgfsdg", "controller"=>"api/v1/posts", "action"=>"update", "id"=>"16", "post"=>{"title"=>"whag", "content"=>"sagsdfdsfdsgfsdg", "category"=>"nh"}} }[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:57:in `update'
+  [1m[36mPost Update (1.9ms)[0m  [1m[33mUPDATE "posts" SET "category" = $1, "updated_at" = $2 WHERE "posts"."id" = $3[0m  [["category", "nh"], ["updated_at", "2024-01-01 13:55:30.626696"], ["id", 16]]
+  ↳ app/controllers/api/v1/posts_controller.rb:57:in `update'
+  [1m[36mTRANSACTION (2.0ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:57:in `update'
+Completed 200 OK in 14ms (Views: 0.6ms | ActiveRecord: 4.8ms | Allocations: 2912)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 21:55:33 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (1.0ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 21ms (Views: 0.9ms | ActiveRecord: 1.8ms | Allocations: 4153)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 21:55:33 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 17ms (Views: 1.3ms | ActiveRecord: 1.3ms | Allocations: 4029)
+
+
+Started POST "/api/v1/show/16" for ::1 at 2024-01-01 21:55:34 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"16", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 16], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007fd4e63908d8>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"16", "post"=>{}} }[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+Completed 200 OK in 8ms (Views: 0.8ms | ActiveRecord: 0.7ms | Allocations: 1155)
+
+
+Started POST "/api/v1/show/16" for ::1 at 2024-01-01 21:55:34 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"16", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 16], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007fd4e63532a8>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"16", "post"=>{}} }[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+Completed 200 OK in 6ms (Views: 0.4ms | ActiveRecord: 0.7ms | Allocations: 1143)
+
+
+Started POST "/validate_token" for ::1 at 2024-01-01 21:56:15 +0800
+Started POST "/validate_token" for ::1 at 2024-01-01 21:56:15 +0800
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 1ms (ActiveRecord: 0.0ms | Allocations: 153)
+
+
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 1ms (ActiveRecord: 0.0ms | Allocations: 154)
+
+
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 21:56:18 +0800
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "post"=>{"title"=>"gh", "category"=>"sdfs", "content"=>"dsgfdsf"}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007fd4ece619a0>, params: {"token"=>"[FILTERED]", "post"=>{"title"=>"gh", "category"=>"sdfs", "content"=>"dsgfdsf"}, "controller"=>"api/v1/posts", "action"=>"create"} }[0m
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mPost Create (1.2ms)[0m  [1m[32mINSERT INTO "posts" ("user_id", "title", "content", "category", "like_count", "dislike_count", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING "id"[0m  [["user_id", 1], ["title", "gh"], ["content", "dsgfdsf"], ["category", "sdfs"], ["like_count", 0], ["dislike_count", 0], ["created_at", "2024-01-01 13:56:18.516601"], ["updated_at", "2024-01-01 13:56:18.516601"]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (0.9ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+Completed 200 OK in 39ms (Views: 0.6ms | ActiveRecord: 13.8ms | Allocations: 10568)
+
+
+Started POST "/api/v1/show/17" for ::1 at 2024-01-01 21:56:18 +0800
+Started POST "/api/v1/show/17" for ::1 at 2024-01-01 21:56:18 +0800
+Processing by Api::V1::PostsController#show as */*
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"17", "post"=>{}}
+  Parameters: {"token"=>"[FILTERED]", "id"=>"17", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 17], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007fd4ecf30340>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"17", "post"=>{}} }[0m
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+Completed 200 OK in 10ms (Views: 0.5ms | ActiveRecord: 0.8ms | Allocations: 2422)
+
+
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 17], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007fd4ecf6fc98>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"17", "post"=>{}} }[0m
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+Completed 200 OK in 20ms (Views: 0.5ms | ActiveRecord: 7.6ms | Allocations: 5303)
+
+
+Started POST "/validate_token" for ::1 at 2024-01-01 21:57:48 +0800
+Started POST "/validate_token" for ::1 at 2024-01-01 21:57:48 +0800
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 1ms (ActiveRecord: 0.0ms | Allocations: 153)
+
+
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 0ms (ActiveRecord: 0.0ms | Allocations: 153)
+
+
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 21:58:00 +0800
+  [1m[36mActiveRecord::SchemaMigration Load (1.4ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "post"=>{"title"=>"gt", "category"=>"sdfa", "content"=>"asdfagfdagfds"}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007fe1530251e8>, params: {"token"=>"[FILTERED]", "post"=>{"title"=>"gt", "category"=>"sdfa", "content"=>"asdfagfdagfds"}, "controller"=>"api/v1/posts", "action"=>"create"} }[0m
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+  [1m[36mCACHE User Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mPost Create (2.5ms)[0m  [1m[32mINSERT INTO "posts" ("user_id", "title", "content", "category", "like_count", "dislike_count", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING "id"[0m  [["user_id", 1], ["title", "gt"], ["content", "asdfagfdagfds"], ["category", "sdfa"], ["like_count", 0], ["dislike_count", 0], ["created_at", "2024-01-01 13:58:01.041002"], ["updated_at", "2024-01-01 13:58:01.041002"]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (9.8ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+Completed 200 OK in 119ms (Views: 0.6ms | ActiveRecord: 26.6ms | Allocations: 30664)
+
+
+Started POST "/api/v1/show/18" for ::1 at 2024-01-01 21:58:01 +0800
+Started POST "/api/v1/show/18" for ::1 at 2024-01-01 21:58:01 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"18", "post"=>{}}
+Processing by Api::V1::PostsController#show as */*
+  [1m[36mPost Load (1.0ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 18], ["LIMIT", 1]]
+  Parameters: {"token"=>"[FILTERED]", "id"=>"18", "post"=>{}}
+  ↳ app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007fe153027b28>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"18", "post"=>{}} }[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+Completed 200 OK in 9ms (Views: 0.4ms | ActiveRecord: 1.3ms | Allocations: 2829)
+
+
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 18], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007fe153023348>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"18", "post"=>{}} }[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+Completed 200 OK in 17ms (Views: 0.4ms | ActiveRecord: 5.2ms | Allocations: 5002)
+
+
+Started POST "/validate_token" for ::1 at 2024-01-01 21:59:01 +0800
+Started POST "/validate_token" for ::1 at 2024-01-01 21:59:01 +0800
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 1ms (ActiveRecord: 0.0ms | Allocations: 169)
+
+
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 1ms (ActiveRecord: 0.0ms | Allocations: 155)
+
+
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 21:59:05 +0800
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "post"=>{"title"=>"t", "category"=>"t", "content"=>"t"}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007fe169a31d60>, params: {"token"=>"[FILTERED]", "post"=>{"title"=>"t", "category"=>"t", "content"=>"t"}, "controller"=>"api/v1/posts", "action"=>"create"} }[0m
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mPost Create (2.0ms)[0m  [1m[32mINSERT INTO "posts" ("user_id", "title", "content", "category", "like_count", "dislike_count", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING "id"[0m  [["user_id", 1], ["title", "t"], ["content", "t"], ["category", "t"], ["like_count", 0], ["dislike_count", 0], ["created_at", "2024-01-01 13:59:05.635682"], ["updated_at", "2024-01-01 13:59:05.635682"]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (1.3ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+Completed 200 OK in 33ms (Views: 0.6ms | ActiveRecord: 12.4ms | Allocations: 10666)
+
+
+Started POST "/api/v1/show/19" for ::1 at 2024-01-01 21:59:05 +0800
+Started POST "/api/v1/show/19" for ::1 at 2024-01-01 21:59:05 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"19", "post"=>{}}
+Completed 400 Bad Request in 1ms (ActiveRecord: 0.0ms | Allocations: 131)
+
+
+  
+ActionController::ParameterMissing (param is missing or the value is empty: post):
+  
+app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"19", "post"=>{}}
+Completed 400 Bad Request in 0ms (ActiveRecord: 0.0ms | Allocations: 93)
+
+
+  
+ActionController::ParameterMissing (param is missing or the value is empty: post):
+  
+app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 21:59:05 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (1.1ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 16ms (Views: 0.9ms | ActiveRecord: 1.8ms | Allocations: 5315)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 21:59:05 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 12ms (Views: 1.3ms | ActiveRecord: 1.4ms | Allocations: 5124)
+
+
+Started POST "/api/v1/show/19" for ::1 at 2024-01-01 21:59:30 +0800
+Started POST "/api/v1/show/19" for ::1 at 2024-01-01 21:59:30 +0800
+  [1m[36mActiveRecord::SchemaMigration Load (1.4ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+Processing by Api::V1::PostsController#show as */*
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"19", "post"=>{}}
+  Parameters: {"token"=>"[FILTERED]", "id"=>"19", "post"=>{}}
+Completed 400 Bad Request in 1ms (ActiveRecord: 8.0ms | Allocations: 226)
+
+
+Completed 400 Bad Request in 0ms (ActiveRecord: 0.0ms | Allocations: 93)
+
+
+  
+ActionController::ParameterMissing (param is missing or the value is empty: post):
+  
+app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+  
+ActionController::ParameterMissing (param is missing or the value is empty: post):
+  
+app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 21:59:30 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (1.0ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 84ms (Views: 1.8ms | ActiveRecord: 5.7ms | Allocations: 26663)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 21:59:30 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 20ms (Views: 1.0ms | ActiveRecord: 1.3ms | Allocations: 5129)
+
+
+Started POST "/api/v1/show/18" for ::1 at 2024-01-01 21:59:36 +0800
+Started POST "/api/v1/show/18" for ::1 at 2024-01-01 21:59:36 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"18", "post"=>{}}
+Processing by Api::V1::PostsController#show as */*
+Completed 400 Bad Request in 0ms (ActiveRecord: 0.0ms | Allocations: 97)
+
+
+  Parameters: {"token"=>"[FILTERED]", "id"=>"18", "post"=>{}}
+  
+ActionController::ParameterMissing (param is missing or the value is empty: post):
+  
+app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+Completed 400 Bad Request in 0ms (ActiveRecord: 0.0ms | Allocations: 93)
+
+
+  
+ActionController::ParameterMissing (param is missing or the value is empty: post):
+  
+app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 21:59:36 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 21ms (Views: 1.5ms | ActiveRecord: 1.6ms | Allocations: 5140)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 21:59:36 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 15ms (Views: 1.3ms | ActiveRecord: 1.3ms | Allocations: 5125)
+
+
+Started POST "/validate_token" for ::1 at 2024-01-01 22:00:11 +0800
+Started POST "/validate_token" for ::1 at 2024-01-01 22:00:11 +0800
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 1ms (ActiveRecord: 0.0ms | Allocations: 352)
+
+
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 0ms (ActiveRecord: 0.0ms | Allocations: 107)
+
+
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 22:00:21 +0800
+  [1m[36mActiveRecord::SchemaMigration Load (1.1ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "post"=>{"title"=>"s", "category"=>"s", "content"=>"s"}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007feb5ddd5338>, params: {"token"=>"[FILTERED]", "post"=>{"title"=>"s", "category"=>"s", "content"=>"s"}, "controller"=>"api/v1/posts", "action"=>"create"} }[0m
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:131:in `authenticate_user'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mPost Create (2.2ms)[0m  [1m[32mINSERT INTO "posts" ("user_id", "title", "content", "category", "like_count", "dislike_count", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING "id"[0m  [["user_id", 1], ["title", "s"], ["content", "s"], ["category", "s"], ["like_count", 0], ["dislike_count", 0], ["created_at", "2024-01-01 14:00:22.168161"], ["updated_at", "2024-01-01 14:00:22.168161"]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (6.8ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+Completed 200 OK in 107ms (Views: 0.7ms | ActiveRecord: 20.2ms | Allocations: 30665)
+
+
+Started POST "/api/v1/show/20" for ::1 at 2024-01-01 22:00:22 +0800
+Started POST "/api/v1/show/20" for ::1 at 2024-01-01 22:00:22 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"20", "post"=>{}}
+Completed 400 Bad Request in 0ms (ActiveRecord: 0.0ms | Allocations: 133)
+
+
+  
+ActionController::ParameterMissing (param is missing or the value is empty: post):
+  
+app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"20", "post"=>{}}
+Completed 400 Bad Request in 0ms (ActiveRecord: 0.0ms | Allocations: 93)
+
+
+  
+ActionController::ParameterMissing (param is missing or the value is empty: post):
+  
+app/controllers/api/v1/posts_controller.rb:161:in `set_post'
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:00:22 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (1.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 16ms (Views: 2.3ms | ActiveRecord: 2.0ms | Allocations: 5708)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:00:22 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 15ms (Views: 1.0ms | ActiveRecord: 1.3ms | Allocations: 5491)
+
+
+Started POST "/api/v1/show/20" for ::1 at 2024-01-01 22:01:28 +0800
+Started POST "/api/v1/show/20" for ::1 at 2024-01-01 22:01:28 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"20", "post"=>{}}
+Completed 400 Bad Request in 1ms (ActiveRecord: 2.8ms | Allocations: 146)
+
+
+  
+ActionController::ParameterMissing (param is missing or the value is empty: post):
+  
+app/controllers/api/v1/posts_controller.rb:162:in `set_post'
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:01:28 +0800
+Processing by Api::V1::PostsController#index as */*
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"20", "post"=>{}}
+Completed 400 Bad Request in 1ms (ActiveRecord: 3.5ms | Allocations: 106)
+
+
+  
+ActionController::ParameterMissing (param is missing or the value is empty: post):
+  
+app/controllers/api/v1/posts_controller.rb:162:in `set_post'
+  [1m[36mPost Load (53.0ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 84ms (Views: 0.9ms | ActiveRecord: 63.1ms | Allocations: 42167)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:01:28 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 14ms (Views: 0.9ms | ActiveRecord: 1.3ms | Allocations: 5491)
+
+
+Started POST "/api/v1/show/19" for ::1 at 2024-01-01 22:01:35 +0800
+Started POST "/api/v1/show/19" for ::1 at 2024-01-01 22:01:35 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"19", "post"=>{}}
+Completed 400 Bad Request in 0ms (ActiveRecord: 0.0ms | Allocations: 94)
+
+
+  
+ActionController::ParameterMissing (param is missing or the value is empty: post):
+  
+app/controllers/api/v1/posts_controller.rb:162:in `set_post'
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"19", "post"=>{}}
+Completed 400 Bad Request in 0ms (ActiveRecord: 0.0ms | Allocations: 93)
+
+
+  
+ActionController::ParameterMissing (param is missing or the value is empty: post):
+  
+app/controllers/api/v1/posts_controller.rb:162:in `set_post'
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:01:35 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.8ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 12ms (Views: 1.6ms | ActiveRecord: 1.3ms | Allocations: 5502)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:01:35 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 12ms (Views: 1.7ms | ActiveRecord: 1.1ms | Allocations: 5489)
+
+
+Started POST "/api/v1/show/20" for ::1 at 2024-01-01 22:01:57 +0800
+Started POST "/api/v1/show/20" for ::1 at 2024-01-01 22:01:57 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"20", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 20], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+Completed 400 Bad Request in 8ms (ActiveRecord: 4.1ms | Allocations: 4005)
+
+
+  
+ActionController::ParameterMissing (param is missing or the value is empty: post):
+  
+app/controllers/api/v1/posts_controller.rb:126:in `authenticate_user'
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:01:57 +0800
+Processing by Api::V1::PostsController#index as */*
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"20", "post"=>{}}
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mPost Load (4.1ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 20], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+Completed 400 Bad Request in 9ms (ActiveRecord: 8.1ms | Allocations: 4947)
+
+
+  
+ActionController::ParameterMissing (param is missing or the value is empty: post):
+  
+app/controllers/api/v1/posts_controller.rb:126:in `authenticate_user'
+  [1m[36mUser Load (30.6ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 65ms (Views: 1.3ms | ActiveRecord: 35.9ms | Allocations: 39897)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:01:57 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.8ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 13ms (Views: 0.9ms | ActiveRecord: 1.4ms | Allocations: 5490)
+
+
+Started POST "/validate_token" for ::1 at 2024-01-01 22:02:25 +0800
+Started POST "/validate_token" for ::1 at 2024-01-01 22:02:25 +0800
+  [1m[36mActiveRecord::SchemaMigration Load (0.8ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+Processing by AuthenticationController#validate as HTML
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 11ms (ActiveRecord: 0.0ms | Allocations: 2718)
+
+
+Completed 204 No Content in 11ms (ActiveRecord: 0.0ms | Allocations: 2530)
+
+
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 22:02:29 +0800
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "post"=>{"title"=>"hi", "category"=>"hi", "content"=>"hi"}}
+Completed 500 Internal Server Error in 1ms (ActiveRecord: 0.0ms | Allocations: 249)
+
+
+  
+NoMethodError (undefined method `id' for nil:NilClass):
+  
+app/controllers/api/v1/posts_controller.rb:126:in `authenticate_user'
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 22:03:27 +0800
+  [1m[36mActiveRecord::SchemaMigration Load (0.7ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "post"=>{"title"=>"hi", "category"=>"hi", "content"=>"hi"}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007f5989855298>, params: {"token"=>"[FILTERED]", "post"=>{"title"=>"hi", "category"=>"hi", "content"=>"hi"}, "controller"=>"api/v1/posts", "action"=>"create"} }[0m
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mPost Create (4.3ms)[0m  [1m[32mINSERT INTO "posts" ("user_id", "title", "content", "category", "like_count", "dislike_count", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING "id"[0m  [["user_id", 1], ["title", "hi"], ["content", "hi"], ["category", "hi"], ["like_count", 0], ["dislike_count", 0], ["created_at", "2024-01-01 14:03:27.376649"], ["updated_at", "2024-01-01 14:03:27.376649"]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (2.2ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+Completed 200 OK in 112ms (Views: 4.0ms | ActiveRecord: 18.0ms | Allocations: 30696)
+
+
+Started POST "/api/v1/show/21" for ::1 at 2024-01-01 22:03:27 +0800
+Processing by Api::V1::PostsController#show as */*
+Started POST "/api/v1/show/21" for ::1 at 2024-01-01 22:03:27 +0800
+  Parameters: {"token"=>"[FILTERED]", "id"=>"21", "post"=>{}}
+Completed 400 Bad Request in 1ms (ActiveRecord: 0.0ms | Allocations: 133)
+
+
+  
+ActionController::ParameterMissing (param is missing or the value is empty: post):
+  
+app/controllers/api/v1/posts_controller.rb:162:in `set_post'
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"21", "post"=>{}}
+Completed 400 Bad Request in 0ms (ActiveRecord: 0.0ms | Allocations: 93)
+
+
+  
+ActionController::ParameterMissing (param is missing or the value is empty: post):
+  
+app/controllers/api/v1/posts_controller.rb:162:in `set_post'
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:03:27 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (1.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 20ms (Views: 5.8ms | ActiveRecord: 2.1ms | Allocations: 6073)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:03:27 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 18ms (Views: 1.5ms | ActiveRecord: 1.3ms | Allocations: 5855)
+
+
+Started POST "/api/v1/show/21" for ::1 at 2024-01-01 22:04:36 +0800
+Started POST "/api/v1/show/21" for ::1 at 2024-01-01 22:04:37 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"21", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 21], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f5989534c58>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"21", "post"=>{}} }[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 25ms (Views: 0.4ms | ActiveRecord: 7.5ms | Allocations: 7725)
+
+
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"21", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 21], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f59897b1af8>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"21", "post"=>{}} }[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 18ms (Views: 0.5ms | ActiveRecord: 5.7ms | Allocations: 7652)
+
+
+Started DELETE "/api/v1/destroy/21" for ::1 at 2024-01-01 22:04:40 +0800
+Processing by Api::V1::PostsController#destroy as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"21", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 21], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: destroy, request: #<ActionDispatch::Request:0x00007f598b828b60>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"destroy", "id"=>"21", "post"=>{}} }[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mPost Destroy (0.9ms)[0m  [1m[31mDELETE FROM "posts" WHERE "posts"."id" = $1[0m  [["id", 21]]
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mTRANSACTION (9.9ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+Completed 200 OK in 16ms (Views: 0.3ms | ActiveRecord: 11.2ms | Allocations: 2422)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:04:40 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 13ms (Views: 1.0ms | ActiveRecord: 1.3ms | Allocations: 5536)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:04:40 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 26ms (Views: 1.8ms | ActiveRecord: 1.4ms | Allocations: 5491)
+
+
+Started POST "/api/v1/show/20" for ::1 at 2024-01-01 22:04:41 +0800
+Started POST "/api/v1/show/20" for ::1 at 2024-01-01 22:04:41 +0800
+Processing by Api::V1::PostsController#show as */*
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"20", "post"=>{}}
+  Parameters: {"token"=>"[FILTERED]", "id"=>"20", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 20], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f59895e3fc8>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"20", "post"=>{}} }[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 7ms (Views: 0.6ms | ActiveRecord: 0.6ms | Allocations: 2212)
+
+
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 20], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f59895e3ac8>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"20", "post"=>{}} }[0m
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 24ms (Views: 0.6ms | ActiveRecord: 9.6ms | Allocations: 5299)
+
+
+Started DELETE "/api/v1/destroy/20" for ::1 at 2024-01-01 22:04:41 +0800
+Processing by Api::V1::PostsController#destroy as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"20", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 20], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: destroy, request: #<ActionDispatch::Request:0x00007f598954e248>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"destroy", "id"=>"20", "post"=>{}} }[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mPost Destroy (5.3ms)[0m  [1m[31mDELETE FROM "posts" WHERE "posts"."id" = $1[0m  [["id", 20]]
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mTRANSACTION (10.0ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+Completed 200 OK in 23ms (Views: 0.2ms | ActiveRecord: 16.1ms | Allocations: 2283)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:04:42 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 12ms (Views: 1.1ms | ActiveRecord: 1.3ms | Allocations: 5125)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:04:42 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.8ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 12ms (Views: 1.0ms | ActiveRecord: 1.7ms | Allocations: 5125)
+
+
+Started POST "/api/v1/show/19" for ::1 at 2024-01-01 22:04:42 +0800
+Started POST "/api/v1/show/19" for ::1 at 2024-01-01 22:04:42 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"19", "post"=>{}}
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 19], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f598966bf40>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"19", "post"=>{}} }[0m
+Processing by Api::V1::PostsController#show as */*
+  [1m[36mUser Load (1.9ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  Parameters: {"token"=>"[FILTERED]", "id"=>"19", "post"=>{}}
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 9ms (Views: 0.6ms | ActiveRecord: 2.4ms | Allocations: 1769)
+
+
+  [1m[36mPost Load (1.1ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 19], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f5989664240>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"19", "post"=>{}} }[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 7ms (Views: 0.4ms | ActiveRecord: 1.4ms | Allocations: 1556)
+
+
+Started DELETE "/api/v1/destroy/19" for ::1 at 2024-01-01 22:04:43 +0800
+Processing by Api::V1::PostsController#destroy as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"19", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 19], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: destroy, request: #<ActionDispatch::Request:0x00007f5989683348>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"destroy", "id"=>"19", "post"=>{}} }[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mPost Destroy (1.7ms)[0m  [1m[31mDELETE FROM "posts" WHERE "posts"."id" = $1[0m  [["id", 19]]
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mTRANSACTION (2.3ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+Completed 200 OK in 12ms (Views: 0.3ms | ActiveRecord: 4.7ms | Allocations: 2283)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:04:43 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 10ms (Views: 0.9ms | ActiveRecord: 1.1ms | Allocations: 4760)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:04:43 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 11ms (Views: 0.8ms | ActiveRecord: 1.3ms | Allocations: 4761)
+
+
+Started POST "/api/v1/show/18" for ::1 at 2024-01-01 22:04:44 +0800
+Started POST "/api/v1/show/18" for ::1 at 2024-01-01 22:04:44 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"18", "post"=>{}}
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"18", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 18], ["LIMIT", 1]]
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 18], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f598b791b98>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"18", "post"=>{}} }[0m
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f598b7aa0a8>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"18", "post"=>{}} }[0m
+  [1m[36mUser Load (0.9ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 8ms (Views: 0.5ms | ActiveRecord: 1.1ms | Allocations: 2155)
+
+
+Completed 200 OK in 8ms (Views: 0.3ms | ActiveRecord: 0.9ms | Allocations: 2266)
+
+
+Started DELETE "/api/v1/destroy/18" for ::1 at 2024-01-01 22:04:45 +0800
+Processing by Api::V1::PostsController#destroy as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"18", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 18], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: destroy, request: #<ActionDispatch::Request:0x00007f598c800150>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"destroy", "id"=>"18", "post"=>{}} }[0m
+  [1m[36mUser Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mPost Destroy (1.1ms)[0m  [1m[31mDELETE FROM "posts" WHERE "posts"."id" = $1[0m  [["id", 18]]
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mTRANSACTION (9.0ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+Completed 200 OK in 15ms (Views: 0.3ms | ActiveRecord: 10.5ms | Allocations: 2283)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:04:45 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 11ms (Views: 1.4ms | ActiveRecord: 1.1ms | Allocations: 4395)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:04:45 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 13ms (Views: 0.9ms | ActiveRecord: 1.1ms | Allocations: 4395)
+
+
+Started POST "/api/v1/show/17" for ::1 at 2024-01-01 22:04:46 +0800
+Started POST "/api/v1/show/17" for ::1 at 2024-01-01 22:04:46 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"17", "post"=>{}}
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"17", "post"=>{}}
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 17], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 17], ["LIMIT", 1]]
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f59896d9248>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"17", "post"=>{}} }[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f59896d8348>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"17", "post"=>{}} }[0m
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mUser Load (1.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+Completed 200 OK in 11ms (Views: 0.4ms | ActiveRecord: 1.5ms | Allocations: 2197)
+
+
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 11ms (Views: 0.4ms | ActiveRecord: 2.0ms | Allocations: 2491)
+
+
+Started DELETE "/api/v1/destroy/17" for ::1 at 2024-01-01 22:04:46 +0800
+Processing by Api::V1::PostsController#destroy as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"17", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 17], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: destroy, request: #<ActionDispatch::Request:0x00007f59896f38f0>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"destroy", "id"=>"17", "post"=>{}} }[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mPost Destroy (0.9ms)[0m  [1m[31mDELETE FROM "posts" WHERE "posts"."id" = $1[0m  [["id", 17]]
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mTRANSACTION (1.3ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+Completed 200 OK in 7ms (Views: 0.2ms | ActiveRecord: 2.6ms | Allocations: 2283)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:04:46 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 14ms (Views: 3.1ms | ActiveRecord: 1.4ms | Allocations: 4029)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:04:46 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 16ms (Views: 1.1ms | ActiveRecord: 1.6ms | Allocations: 4029)
+
+
+Started POST "/api/v1/show/16" for ::1 at 2024-01-01 22:04:47 +0800
+Started POST "/api/v1/show/16" for ::1 at 2024-01-01 22:04:47 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"16", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 16], ["LIMIT", 1]]
+Processing by Api::V1::PostsController#show as */*
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+  Parameters: {"token"=>"[FILTERED]", "id"=>"16", "post"=>{}}
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f59895ace60>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"16", "post"=>{}} }[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 16], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+Completed 200 OK in 7ms (Views: 0.4ms | ActiveRecord: 0.7ms | Allocations: 1999)
+
+
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f59895a9bc0>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"16", "post"=>{}} }[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 7ms (Views: 0.5ms | ActiveRecord: 0.6ms | Allocations: 2040)
+
+
+Started DELETE "/api/v1/destroy/16" for ::1 at 2024-01-01 22:04:48 +0800
+Processing by Api::V1::PostsController#destroy as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"16", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 16], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: destroy, request: #<ActionDispatch::Request:0x00007f5989604110>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"destroy", "id"=>"16", "post"=>{}} }[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mPost Destroy (1.5ms)[0m  [1m[31mDELETE FROM "posts" WHERE "posts"."id" = $1[0m  [["id", 16]]
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mTRANSACTION (1.6ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+Completed 200 OK in 11ms (Views: 0.4ms | ActiveRecord: 3.7ms | Allocations: 2283)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:04:48 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 11ms (Views: 2.4ms | ActiveRecord: 1.1ms | Allocations: 3663)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:04:48 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 13ms (Views: 1.2ms | ActiveRecord: 1.2ms | Allocations: 3663)
+
+
+Started POST "/api/v1/show/15" for ::1 at 2024-01-01 22:04:48 +0800
+Started POST "/api/v1/show/15" for ::1 at 2024-01-01 22:04:48 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"15", "post"=>{}}
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"15", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 15], ["LIMIT", 1]]
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 15], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f598973a0c0>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"15", "post"=>{}} }[0m
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f59897399e0>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"15", "post"=>{}} }[0m
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 8ms (Views: 0.5ms | ActiveRecord: 0.7ms | Allocations: 2155)
+
+
+Completed 200 OK in 8ms (Views: 0.3ms | ActiveRecord: 0.6ms | Allocations: 2266)
+
+
+Started DELETE "/api/v1/destroy/15" for ::1 at 2024-01-01 22:04:49 +0800
+Processing by Api::V1::PostsController#destroy as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"15", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 15], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: destroy, request: #<ActionDispatch::Request:0x00007f5989755140>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"destroy", "id"=>"15", "post"=>{}} }[0m
+  [1m[36mUser Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mPost Destroy (1.1ms)[0m  [1m[31mDELETE FROM "posts" WHERE "posts"."id" = $1[0m  [["id", 15]]
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mTRANSACTION (1.9ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+Completed 200 OK in 7ms (Views: 0.2ms | ActiveRecord: 3.4ms | Allocations: 2283)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:04:49 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 6ms (Views: 0.9ms | ActiveRecord: 0.8ms | Allocations: 3299)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:04:49 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 9ms (Views: 0.9ms | ActiveRecord: 1.2ms | Allocations: 3298)
+
+
+Started POST "/api/v1/show/14" for ::1 at 2024-01-01 22:04:50 +0800
+Started POST "/api/v1/show/14" for ::1 at 2024-01-01 22:04:50 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"14", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 14], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f598d7f87b0>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"14", "post"=>{}} }[0m
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 6ms (Views: 0.4ms | ActiveRecord: 0.7ms | Allocations: 1250)
+
+
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"14", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 14], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f59895c4ec0>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"14", "post"=>{}} }[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 6ms (Views: 0.5ms | ActiveRecord: 0.6ms | Allocations: 1142)
+
+
+Started DELETE "/api/v1/destroy/14" for ::1 at 2024-01-01 22:04:51 +0800
+Processing by Api::V1::PostsController#destroy as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"14", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 14], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: destroy, request: #<ActionDispatch::Request:0x00007f59896a76d0>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"destroy", "id"=>"14", "post"=>{}} }[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mPost Destroy (1.0ms)[0m  [1m[31mDELETE FROM "posts" WHERE "posts"."id" = $1[0m  [["id", 14]]
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mTRANSACTION (10.4ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+Completed 200 OK in 18ms (Views: 0.4ms | ActiveRecord: 11.9ms | Allocations: 2283)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:04:51 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 8ms (Views: 1.3ms | ActiveRecord: 1.0ms | Allocations: 2934)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:04:51 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 9ms (Views: 1.1ms | ActiveRecord: 1.3ms | Allocations: 2934)
+
+
+Started POST "/api/v1/show/13" for ::1 at 2024-01-01 22:04:51 +0800
+Started POST "/api/v1/show/13" for ::1 at 2024-01-01 22:04:51 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"13", "post"=>{}}
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"13", "post"=>{}}
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 13], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+  [1m[36mPost Load (1.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 13], ["LIMIT", 1]]
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f59895ec448>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"13", "post"=>{}} }[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f59895eae68>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"13", "post"=>{}} }[0m
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mUser Load (0.7ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+Completed 200 OK in 9ms (Views: 0.4ms | ActiveRecord: 1.1ms | Allocations: 2195)
+
+
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 9ms (Views: 0.3ms | ActiveRecord: 2.1ms | Allocations: 2488)
+
+
+Started DELETE "/api/v1/destroy/13" for ::1 at 2024-01-01 22:04:52 +0800
+Processing by Api::V1::PostsController#destroy as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"13", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 13], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: destroy, request: #<ActionDispatch::Request:0x00007f5989504bc0>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"destroy", "id"=>"13", "post"=>{}} }[0m
+  [1m[36mUser Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mPost Destroy (1.2ms)[0m  [1m[31mDELETE FROM "posts" WHERE "posts"."id" = $1[0m  [["id", 13]]
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mTRANSACTION (9.6ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+Completed 200 OK in 16ms (Views: 0.3ms | ActiveRecord: 11.2ms | Allocations: 2283)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:04:52 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 7ms (Views: 1.1ms | ActiveRecord: 1.0ms | Allocations: 2568)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:04:52 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.8ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 7ms (Views: 0.6ms | ActiveRecord: 1.3ms | Allocations: 2568)
+
+
+Started POST "/api/v1/show/11" for ::1 at 2024-01-01 22:04:53 +0800
+Started POST "/api/v1/show/11" for ::1 at 2024-01-01 22:04:53 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"11", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 11], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f59895a6420>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"11", "post"=>{}} }[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 10ms (Views: 0.5ms | ActiveRecord: 0.6ms | Allocations: 1290)
+
+
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"11", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 11], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f59896087b0>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"11", "post"=>{}} }[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 5ms (Views: 0.6ms | ActiveRecord: 0.6ms | Allocations: 1142)
+
+
+Started DELETE "/api/v1/destroy/11" for ::1 at 2024-01-01 22:04:53 +0800
+Processing by Api::V1::PostsController#destroy as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"11", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 11], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: destroy, request: #<ActionDispatch::Request:0x00007f598962b058>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"destroy", "id"=>"11", "post"=>{}} }[0m
+  [1m[36mUser Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mPost Destroy (1.1ms)[0m  [1m[31mDELETE FROM "posts" WHERE "posts"."id" = $1[0m  [["id", 11]]
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mTRANSACTION (1.9ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+Completed 200 OK in 9ms (Views: 0.3ms | ActiveRecord: 3.5ms | Allocations: 2283)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:04:53 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 8ms (Views: 0.9ms | ActiveRecord: 1.4ms | Allocations: 2203)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:04:53 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 9ms (Views: 0.7ms | ActiveRecord: 1.3ms | Allocations: 2203)
+
+
+Started POST "/api/v1/show/8" for ::1 at 2024-01-01 22:04:54 +0800
+Started POST "/api/v1/show/8" for ::1 at 2024-01-01 22:04:54 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"8", "post"=>{}}
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"8", "post"=>{}}
+  [1m[36mPost Load (0.8ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 8], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 8], ["LIMIT", 1]]
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f5989715018>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"8", "post"=>{}} }[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f5989713b78>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"8", "post"=>{}} }[0m
+  [1m[36mUser Load (1.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 9ms (Views: 0.4ms | ActiveRecord: 2.0ms | Allocations: 2489)
+
+
+Completed 200 OK in 7ms (Views: 0.3ms | ActiveRecord: 0.9ms | Allocations: 2251)
+
+
+Started DELETE "/api/v1/destroy/8" for ::1 at 2024-01-01 22:04:55 +0800
+Processing by Api::V1::PostsController#destroy as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"8", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 8], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: destroy, request: #<ActionDispatch::Request:0x00007f598975f320>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"destroy", "id"=>"8", "post"=>{}} }[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mPost Destroy (1.4ms)[0m  [1m[31mDELETE FROM "posts" WHERE "posts"."id" = $1[0m  [["id", 8]]
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mTRANSACTION (9.5ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+Completed 200 OK in 19ms (Views: 0.4ms | ActiveRecord: 11.6ms | Allocations: 2283)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:04:55 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.8ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 7ms (Views: 0.5ms | ActiveRecord: 1.2ms | Allocations: 1839)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:04:55 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 8ms (Views: 0.5ms | ActiveRecord: 1.1ms | Allocations: 1838)
+
+
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 22:04:56 +0800
+Started POST "/api/v1/show/7" for ::1 at 2024-01-01 22:04:56 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f598b7da820>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"7", "post"=>{}} }[0m
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Processing by Api::V1::PostsController#show as */*
+Completed 200 OK in 5ms (Views: 0.4ms | ActiveRecord: 0.8ms | Allocations: 1654)
+
+
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f598c80d670>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"7", "post"=>{}} }[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 5ms (Views: 0.6ms | ActiveRecord: 0.5ms | Allocations: 1143)
+
+
+Started DELETE "/api/v1/destroy/7" for ::1 at 2024-01-01 22:04:56 +0800
+Processing by Api::V1::PostsController#destroy as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"7", "post"=>{}}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 7], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: destroy, request: #<ActionDispatch::Request:0x00007f59895cdfc0>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"destroy", "id"=>"7", "post"=>{}} }[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mPost Destroy (1.5ms)[0m  [1m[31mDELETE FROM "posts" WHERE "posts"."id" = $1[0m  [["id", 7]]
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mTRANSACTION (2.1ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+Completed 200 OK in 10ms (Views: 0.3ms | ActiveRecord: 4.1ms | Allocations: 2283)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:04:56 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 5ms (Views: 0.7ms | ActiveRecord: 0.8ms | Allocations: 1363)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:04:56 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 9ms (Views: 1.0ms | ActiveRecord: 0.7ms | Allocations: 1364)
+
+
+Started POST "/validate_token" for ::1 at 2024-01-01 22:04:59 +0800
+Started POST "/validate_token" for ::1 at 2024-01-01 22:04:59 +0800
+Processing by AuthenticationController#validate as HTML
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 1ms (ActiveRecord: 0.0ms | Allocations: 161)
+
+
+Completed 204 No Content in 0ms (ActiveRecord: 0.0ms | Allocations: 106)
+
+
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 22:05:30 +0800
+  [1m[36mActiveRecord::SchemaMigration Load (1.5ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "post"=>{"title"=>"h", "category"=>"h", "content"=>"h"}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007f9e9a2b5328>, params: {"token"=>"[FILTERED]", "post"=>{"title"=>"h", "category"=>"h", "content"=>"h"}, "controller"=>"api/v1/posts", "action"=>"create"} }[0m
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mCACHE User Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mPost Create (2.2ms)[0m  [1m[32mINSERT INTO "posts" ("user_id", "title", "content", "category", "like_count", "dislike_count", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING "id"[0m  [["user_id", 1], ["title", "h"], ["content", "h"], ["category", "h"], ["like_count", 0], ["dislike_count", 0], ["created_at", "2024-01-01 14:05:30.899395"], ["updated_at", "2024-01-01 14:05:30.899395"]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (10.7ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+Completed 200 OK in 118ms (Views: 1.1ms | ActiveRecord: 26.2ms | Allocations: 30660)
+
+
+Started POST "/api/v1/show/22" for ::1 at 2024-01-01 22:05:30 +0800
+Started POST "/api/v1/show/22" for ::1 at 2024-01-01 22:05:31 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"22", "post"=>{}}
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"22", "post"=>{}}
+  [1m[36mPost Load (0.9ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 22], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f9e9a2b9608>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"22", "post"=>{}} }[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 9ms (Views: 0.5ms | ActiveRecord: 1.2ms | Allocations: 2893)
+
+
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 22], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f9e9a2b3208>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"22", "post"=>{}} }[0m
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 19ms (Views: 0.4ms | ActiveRecord: 8.2ms | Allocations: 5308)
+
+
+Started POST "/validate_token" for ::1 at 2024-01-01 22:06:21 +0800
+Started POST "/validate_token" for ::1 at 2024-01-01 22:06:21 +0800
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 1ms (ActiveRecord: 0.0ms | Allocations: 169)
+
+
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 0ms (ActiveRecord: 0.0ms | Allocations: 155)
+
+
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 22:06:25 +0800
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "post"=>{"title"=>"f", "category"=>"f", "content"=>"f"}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007f9e9ccb1a50>, params: {"token"=>"[FILTERED]", "post"=>{"title"=>"f", "category"=>"f", "content"=>"f"}, "controller"=>"api/v1/posts", "action"=>"create"} }[0m
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mPost Create (2.3ms)[0m  [1m[32mINSERT INTO "posts" ("user_id", "title", "content", "category", "like_count", "dislike_count", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING "id"[0m  [["user_id", 1], ["title", "f"], ["content", "f"], ["category", "f"], ["like_count", 0], ["dislike_count", 0], ["created_at", "2024-01-01 14:06:25.231027"], ["updated_at", "2024-01-01 14:06:25.231027"]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (1.2ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+Completed 200 OK in 31ms (Views: 0.5ms | ActiveRecord: 11.6ms | Allocations: 10662)
+
+
+Started POST "/api/v1/show/23" for ::1 at 2024-01-01 22:06:25 +0800
+Started POST "/api/v1/show/23" for ::1 at 2024-01-01 22:06:25 +0800
+Processing by Api::V1::PostsController#show as */*
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"23", "post"=>{}}
+  Parameters: {"token"=>"[FILTERED]", "id"=>"23", "post"=>{}}
+[31mUnpermitted parameters: :token, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f9e9a1d0480>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"23", "post"=>{}} }[0m
+[31mUnpermitted parameters: :token, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f9e9a1bfe78>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"23", "post"=>{}} }[0m
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 23], ["LIMIT", 1]]
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 23], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:164:in `set_post'
+  ↳ app/controllers/api/v1/posts_controller.rb:164:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f9e9a1d0480>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"23", "post"=>{}} }[0m
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f9e9a1bfe78>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"23", "post"=>{}} }[0m
+  [1m[36mUser Load (1.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mUser Load (0.8ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+Completed 200 OK in 10ms (Views: 1.0ms | ActiveRecord: 1.4ms | Allocations: 2275)
+
+
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 12ms (Views: 0.4ms | ActiveRecord: 1.2ms | Allocations: 2879)
+
+
+Started DELETE "/api/v1/destroy/23" for ::1 at 2024-01-01 22:08:12 +0800
+Processing by Api::V1::PostsController#destroy as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"23", "post"=>{}}
+[31mUnpermitted parameters: :token, :post. Context: { controller: Api::V1::PostsController, action: destroy, request: #<ActionDispatch::Request:0x00007f9e9a106cc0>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"destroy", "id"=>"23", "post"=>{}} }[0m
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 23], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:165:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: destroy, request: #<ActionDispatch::Request:0x00007f9e9a106cc0>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"destroy", "id"=>"23", "post"=>{}} }[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mPost Destroy (1.3ms)[0m  [1m[31mDELETE FROM "posts" WHERE "posts"."id" = $1[0m  [["id", 23]]
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mTRANSACTION (1.3ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+Completed 200 OK in 28ms (Views: 0.4ms | ActiveRecord: 10.0ms | Allocations: 9016)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:08:12 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (1.1ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 8ms (Views: 0.6ms | ActiveRecord: 1.8ms | Allocations: 1970)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:08:12 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.8ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 7ms (Views: 0.5ms | ActiveRecord: 1.4ms | Allocations: 1837)
+
+
+Started POST "/validate_token" for ::1 at 2024-01-01 22:08:13 +0800
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 1ms (ActiveRecord: 0.0ms | Allocations: 144)
+
+
+Started POST "/validate_token" for ::1 at 2024-01-01 22:08:13 +0800
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 0ms (ActiveRecord: 0.0ms | Allocations: 105)
+
+
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 22:08:24 +0800
+  [1m[36mActiveRecord::SchemaMigration Load (0.9ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "post"=>{"title"=>"f", "category"=>"f", "content"=>"f"}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007f3f84ab5200>, params: {"token"=>"[FILTERED]", "post"=>{"title"=>"f", "category"=>"f", "content"=>"f"}, "controller"=>"api/v1/posts", "action"=>"create"} }[0m
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mPost Create (2.3ms)[0m  [1m[32mINSERT INTO "posts" ("user_id", "title", "content", "category", "like_count", "dislike_count", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING "id"[0m  [["user_id", 1], ["title", "f"], ["content", "f"], ["category", "f"], ["like_count", 0], ["dislike_count", 0], ["created_at", "2024-01-01 14:08:24.547835"], ["updated_at", "2024-01-01 14:08:24.547835"]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (9.3ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+Completed 200 OK in 118ms (Views: 0.5ms | ActiveRecord: 23.7ms | Allocations: 30672)
+
+
+Started POST "/api/v1/show/24" for ::1 at 2024-01-01 22:08:24 +0800
+Processing by Api::V1::PostsController#show as */*
+Started POST "/api/v1/show/24" for ::1 at 2024-01-01 22:08:24 +0800
+  Parameters: {"token"=>"[FILTERED]", "id"=>"24", "post"=>{}}
+[31mUnpermitted parameters: :token, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f3f84a51ea8>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"24", "post"=>{}} }[0m
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 24], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:165:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f3f84a51ea8>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"24", "post"=>{}} }[0m
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 8ms (Views: 0.5ms | ActiveRecord: 0.9ms | Allocations: 1668)
+
+
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"24", "post"=>{}}
+[31mUnpermitted parameters: :token, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f3f84a0fa08>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"24", "post"=>{}} }[0m
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 24], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:165:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f3f84a0fa08>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"24", "post"=>{}} }[0m
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 7ms (Views: 0.6ms | ActiveRecord: 0.8ms | Allocations: 1264)
+
+
+Started DELETE "/api/v1/destroy/24" for ::1 at 2024-01-01 22:10:02 +0800
+Processing by Api::V1::PostsController#destroy as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"24", "post"=>{}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: destroy, request: #<ActionDispatch::Request:0x00007f3f87533cc0>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"destroy", "id"=>"24", "post"=>{}} }[0m
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 24], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:165:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: destroy, request: #<ActionDispatch::Request:0x00007f3f87533cc0>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"destroy", "id"=>"24", "post"=>{}} }[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mPost Destroy (1.2ms)[0m  [1m[31mDELETE FROM "posts" WHERE "posts"."id" = $1[0m  [["id", 24]]
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mTRANSACTION (1.6ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+Completed 200 OK in 29ms (Views: 0.3ms | ActiveRecord: 10.6ms | Allocations: 9067)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:10:02 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.8ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 8ms (Views: 0.5ms | ActiveRecord: 1.5ms | Allocations: 1970)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:10:02 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (1.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 9ms (Views: 0.7ms | ActiveRecord: 1.8ms | Allocations: 1837)
+
+
+Started POST "/api/v1/show/22" for ::1 at 2024-01-01 22:10:04 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"22", "post"=>{}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f3f8747a5b8>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"22", "post"=>{}} }[0m
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 22], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:165:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f3f8747a5b8>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"22", "post"=>{}} }[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 8ms (Views: 0.8ms | ActiveRecord: 0.7ms | Allocations: 1280)
+
+
+Started POST "/api/v1/show/22" for ::1 at 2024-01-01 22:10:04 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"22", "post"=>{}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f3f8745cc70>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"22", "post"=>{}} }[0m
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 22], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:165:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f3f8745cc70>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"22", "post"=>{}} }[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 6ms (Views: 0.4ms | ActiveRecord: 0.6ms | Allocations: 1268)
+
+
+Started DELETE "/api/v1/destroy/22" for ::1 at 2024-01-01 22:10:05 +0800
+Processing by Api::V1::PostsController#destroy as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"22", "post"=>{}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: destroy, request: #<ActionDispatch::Request:0x00007f3f8743f1e8>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"destroy", "id"=>"22", "post"=>{}} }[0m
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 22], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:165:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: destroy, request: #<ActionDispatch::Request:0x00007f3f8743f1e8>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"destroy", "id"=>"22", "post"=>{}} }[0m
+  [1m[36mUser Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mPost Destroy (0.9ms)[0m  [1m[31mDELETE FROM "posts" WHERE "posts"."id" = $1[0m  [["id", 22]]
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mTRANSACTION (9.3ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+Completed 200 OK in 16ms (Views: 0.4ms | ActiveRecord: 10.6ms | Allocations: 2396)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:10:05 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (1.1ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 7ms (Views: 0.7ms | ActiveRecord: 1.3ms | Allocations: 1363)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:10:05 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 4ms (Views: 0.7ms | ActiveRecord: 0.7ms | Allocations: 1363)
+
+
+Started POST "/validate_token" for ::1 at 2024-01-01 22:10:06 +0800
+Started POST "/validate_token" for ::1 at 2024-01-01 22:10:06 +0800
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Processing by AuthenticationController#validate as HTML
+Completed 204 No Content in 1ms (ActiveRecord: 0.0ms | Allocations: 162)
+
+
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 0ms (ActiveRecord: 0.0ms | Allocations: 106)
+
+
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 22:10:17 +0800
+  [1m[36mActiveRecord::SchemaMigration Load (0.6ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "post"=>{"title"=>"f", "category"=>"f", "content"=>"f"}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007f40d7f85290>, params: {"token"=>"[FILTERED]", "post"=>{"title"=>"f", "category"=>"f", "content"=>"f"}, "controller"=>"api/v1/posts", "action"=>"create"} }[0m
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mPost Create (10.8ms)[0m  [1m[32mINSERT INTO "posts" ("user_id", "title", "content", "category", "like_count", "dislike_count", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING "id"[0m  [["user_id", 1], ["title", "f"], ["content", "f"], ["category", "f"], ["like_count", 0], ["dislike_count", 0], ["created_at", "2024-01-01 14:10:17.255362"], ["updated_at", "2024-01-01 14:10:17.255362"]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (9.5ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+Completed 200 OK in 127ms (Views: 0.6ms | ActiveRecord: 31.9ms | Allocations: 30671)
+
+
+Started POST "/api/v1/show/25" for ::1 at 2024-01-01 22:10:17 +0800
+Processing by Api::V1::PostsController#show as */*
+Started POST "/api/v1/show/25" for ::1 at 2024-01-01 22:10:17 +0800
+  Parameters: {"token"=>"[FILTERED]", "id"=>"25", "post"=>{}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f40d7f21c40>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"25", "post"=>{}} }[0m
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 25], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:165:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f40d7f21c40>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"25", "post"=>{}} }[0m
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 6ms (Views: 0.5ms | ActiveRecord: 0.8ms | Allocations: 1674)
+
+
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"25", "post"=>{}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f4104013fc8>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"25", "post"=>{}} }[0m
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 25], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:165:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f4104013fc8>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"25", "post"=>{}} }[0m
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 10ms (Views: 1.0ms | ActiveRecord: 0.7ms | Allocations: 1269)
+
+
+Started DELETE "/api/v1/destroy/25" for ::1 at 2024-01-01 22:11:49 +0800
+  [1m[36mActiveRecord::SchemaMigration Load (1.2ms)[0m  [1m[34mSELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC[0m
+Processing by Api::V1::PostsController#destroy as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"25", "post"=>{}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: destroy, request: #<ActionDispatch::Request:0x00007f86299f50b8>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"destroy", "id"=>"25", "post"=>{}} }[0m
+Completed 400 Bad Request in 1ms (ActiveRecord: 5.0ms | Allocations: 372)
+
+
+  
+ActionController::ParameterMissing (param is missing or the value is empty: post):
+  
+app/controllers/api/v1/posts_controller.rb:163:in `set_post'
+Started DELETE "/api/v1/destroy/25" for ::1 at 2024-01-01 22:12:24 +0800
+Processing by Api::V1::PostsController#destroy as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"25", "post"=>{}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: destroy, request: #<ActionDispatch::Request:0x00007f862c4265f8>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"destroy", "id"=>"25", "post"=>{}} }[0m
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 25], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:165:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: destroy, request: #<ActionDispatch::Request:0x00007f862c4265f8>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"destroy", "id"=>"25", "post"=>{}} }[0m
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mTRANSACTION (0.4ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mPost Destroy (3.0ms)[0m  [1m[31mDELETE FROM "posts" WHERE "posts"."id" = $1[0m  [["id", 25]]
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mTRANSACTION (1.0ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+Completed 200 OK in 83ms (Views: 0.2ms | ActiveRecord: 13.5ms | Allocations: 24278)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:12:24 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.8ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 7ms (Views: 0.7ms | ActiveRecord: 1.1ms | Allocations: 1647)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:12:24 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 6ms (Views: 0.7ms | ActiveRecord: 0.7ms | Allocations: 1363)
+
+
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 22:33:24 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f862c464ce0>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"5", "post"=>{}} }[0m
+Started POST "/api/v1/show/5" for ::1 at 2024-01-01 22:33:24 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"5", "post"=>{}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f862980d700>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"5", "post"=>{}} }[0m
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:165:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f862c464ce0>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"5", "post"=>{}} }[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 21ms (Views: 0.5ms | ActiveRecord: 7.7ms | Allocations: 7309)
+
+
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 5], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:165:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f862980d700>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"5", "post"=>{}} }[0m
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 21ms (Views: 0.5ms | ActiveRecord: 8.0ms | Allocations: 6949)
+
+
+Started POST "/validate_token" for ::1 at 2024-01-01 22:33:25 +0800
+Started POST "/validate_token" for ::1 at 2024-01-01 22:33:25 +0800
+Processing by AuthenticationController#validate as HTML
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 1ms (ActiveRecord: 0.0ms | Allocations: 159)
+
+
+Completed 204 No Content in 0ms (ActiveRecord: 0.0ms | Allocations: 117)
+
+
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 22:33:29 +0800
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "post"=>{"title"=>"h", "category"=>"h", "content"=>"h"}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: create, request: #<ActionDispatch::Request:0x00007f86298629f8>, params: {"token"=>"[FILTERED]", "post"=>{"title"=>"h", "category"=>"h", "content"=>"h"}, "controller"=>"api/v1/posts", "action"=>"create"} }[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mPost Create (3.1ms)[0m  [1m[32mINSERT INTO "posts" ("user_id", "title", "content", "category", "like_count", "dislike_count", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING "id"[0m  [["user_id", 1], ["title", "h"], ["content", "h"], ["category", "h"], ["like_count", 0], ["dislike_count", 0], ["created_at", "2024-01-01 14:33:29.337916"], ["updated_at", "2024-01-01 14:33:29.337916"]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (1.7ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+Completed 200 OK in 19ms (Views: 0.5ms | ActiveRecord: 5.2ms | Allocations: 5038)
+
+
+Started POST "/api/v1/show/26" for ::1 at 2024-01-01 22:33:29 +0800
+Started POST "/api/v1/show/26" for ::1 at 2024-01-01 22:33:29 +0800
+Processing by Api::V1::PostsController#show as */*
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"26", "post"=>{}}
+  Parameters: {"token"=>"[FILTERED]", "id"=>"26", "post"=>{}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f86298f1cc0>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"26", "post"=>{}} }[0m
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f86298f17c0>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"26", "post"=>{}} }[0m
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 26], ["LIMIT", 1]]
+  [1m[36mPost Load (0.8ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 26], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:165:in `set_post'
+  ↳ app/controllers/api/v1/posts_controller.rb:165:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f86298f17c0>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"26", "post"=>{}} }[0m
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f86298f1cc0>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"26", "post"=>{}} }[0m
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+Completed 200 OK in 8ms (Views: 0.6ms | ActiveRecord: 0.9ms | Allocations: 1968)
+
+
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 10ms (Views: 0.4ms | ActiveRecord: 1.5ms | Allocations: 2790)
+
+
+Started PATCH "/api/v1/update/26" for ::1 at 2024-01-01 22:33:34 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"w", "category"=>"w", "content"=>"w", "id"=>"26", "post"=>{"title"=>"w", "content"=>"w", "category"=>"w"}}
+[31mUnpermitted parameters: :title, :category, :content, :post. Context: { controller: Api::V1::PostsController, action: update, request: #<ActionDispatch::Request:0x00007f862993cb30>, params: {"token"=>"[FILTERED]", "title"=>"w", "category"=>"w", "content"=>"w", "controller"=>"api/v1/posts", "action"=>"update", "id"=>"26", "post"=>{"title"=>"w", "content"=>"w", "category"=>"w"}} }[0m
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 26], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:165:in `set_post'
+[31mUnpermitted parameters: :title, :category, :content, :id, :post. Context: { controller: Api::V1::PostsController, action: update, request: #<ActionDispatch::Request:0x00007f862993cb30>, params: {"token"=>"[FILTERED]", "title"=>"w", "category"=>"w", "content"=>"w", "controller"=>"api/v1/posts", "action"=>"update", "id"=>"26", "post"=>{"title"=>"w", "content"=>"w", "category"=>"w"}} }[0m
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:57:in `update'
+  [1m[36mPost Update (2.2ms)[0m  [1m[33mUPDATE "posts" SET "title" = $1, "content" = $2, "category" = $3, "updated_at" = $4 WHERE "posts"."id" = $5[0m  [["title", "w"], ["content", "w"], ["category", "w"], ["updated_at", "2024-01-01 14:33:34.893856"], ["id", 26]]
+  ↳ app/controllers/api/v1/posts_controller.rb:57:in `update'
+  [1m[36mTRANSACTION (3.0ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:57:in `update'
+Completed 200 OK in 25ms (Views: 0.5ms | ActiveRecord: 6.2ms | Allocations: 3036)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:33:36 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (1.0ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 8ms (Views: 0.5ms | ActiveRecord: 1.6ms | Allocations: 1837)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:33:36 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 8ms (Views: 0.5ms | ActiveRecord: 1.1ms | Allocations: 1837)
+
+
+Started POST "/api/v1/show/26" for ::1 at 2024-01-01 22:33:38 +0800
+Started POST "/api/v1/show/26" for ::1 at 2024-01-01 22:33:38 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"26", "post"=>{}}
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f862c474438>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"26", "post"=>{}} }[0m
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 26], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:165:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f862c474438>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"26", "post"=>{}} }[0m
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+Processing by Api::V1::PostsController#show as */*
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  Parameters: {"token"=>"[FILTERED]", "id"=>"26", "post"=>{}}
+Completed 200 OK in 8ms (Views: 0.4ms | ActiveRecord: 0.8ms | Allocations: 1801)
+
+
+[31mUnpermitted parameter: :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f862c407ef0>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"26", "post"=>{}} }[0m
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 26], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:165:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f862c407ef0>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"26", "post"=>{}} }[0m
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 7ms (Views: 0.5ms | ActiveRecord: 0.6ms | Allocations: 1498)
+
+
+Started DELETE "/api/v1/destroy/26" for ::1 at 2024-01-01 22:39:37 +0800
+  
+SyntaxError (/home/pengxuan/CVWO/CVWO_backend/app/controllers/api/v1/posts_controller.rb:163: syntax error, unexpected ':', expecting ')'
+...rams.permit(:id, :token, :post: {})
+...                              ^
+):
+  
+app/controllers/api/v1/posts_controller.rb:163: syntax error, unexpected ':', expecting ')'
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:39:51 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 31ms (Views: 0.9ms | ActiveRecord: 6.4ms | Allocations: 11968)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:39:52 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 8ms (Views: 0.7ms | ActiveRecord: 1.3ms | Allocations: 1838)
+
+
+Started POST "/api/v1/show/26" for ::1 at 2024-01-01 22:39:53 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"26", "post"=>{}}
+  [1m[36mPost Load (0.5ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 26], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:165:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f862c454bb0>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"26", "post"=>{}} }[0m
+Started POST "/api/v1/show/26" for ::1 at 2024-01-01 22:39:53 +0800
+  [1m[36mUser Load (1.6ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 9ms (Views: 0.4ms | ActiveRecord: 2.0ms | Allocations: 1645)
+
+
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"26", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 26], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:165:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: show, request: #<ActionDispatch::Request:0x00007f8629807260>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"show", "id"=>"26", "post"=>{}} }[0m
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 5ms (Views: 0.4ms | ActiveRecord: 0.8ms | Allocations: 1198)
+
+
+Started DELETE "/api/v1/destroy/26" for ::1 at 2024-01-01 22:39:54 +0800
+Processing by Api::V1::PostsController#destroy as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"26", "post"=>{}}
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 26], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:165:in `set_post'
+[31mUnpermitted parameters: :id, :post. Context: { controller: Api::V1::PostsController, action: destroy, request: #<ActionDispatch::Request:0x00007f8629825468>, params: {"token"=>"[FILTERED]", "controller"=>"api/v1/posts", "action"=>"destroy", "id"=>"26", "post"=>{}} }[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mTRANSACTION (0.1ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mPost Destroy (1.1ms)[0m  [1m[31mDELETE FROM "posts" WHERE "posts"."id" = $1[0m  [["id", 26]]
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+  [1m[36mTRANSACTION (2.2ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:119:in `destroy'
+Completed 200 OK in 9ms (Views: 0.2ms | ActiveRecord: 3.8ms | Allocations: 2387)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:39:54 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 6ms (Views: 1.1ms | ActiveRecord: 0.8ms | Allocations: 1362)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 22:39:54 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 6ms (Views: 0.5ms | ActiveRecord: 0.9ms | Allocations: 1362)
+
+
+Started POST "/validate_token" for ::1 at 2024-01-01 22:50:21 +0800
+Started POST "/validate_token" for ::1 at 2024-01-01 22:50:21 +0800
+Processing by AuthenticationController#validate as HTML
+Processing by AuthenticationController#validate as HTML
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+  Parameters: {"token"=>"[FILTERED]", "authentication"=>{"token"=>"[FILTERED]"}}
+Completed 204 No Content in 1ms (ActiveRecord: 0.0ms | Allocations: 156)
+
+
+Completed 204 No Content in 0ms (ActiveRecord: 0.0ms | Allocations: 107)
+
+
+Started POST "/api/v1/posts/create" for ::1 at 2024-01-01 22:50:24 +0800
+Processing by Api::V1::PostsController#create as */*
+  Parameters: {"token"=>"[FILTERED]", "post"=>{"title"=>"t", "category"=>"t", "content"=>"t"}}
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (0.3ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mPost Create (1.7ms)[0m  [1m[32mINSERT INTO "posts" ("user_id", "title", "content", "category", "like_count", "dislike_count", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING "id"[0m  [["user_id", 1], ["title", "t"], ["content", "t"], ["category", "t"], ["like_count", 0], ["dislike_count", 0], ["created_at", "2024-01-01 14:50:24.201717"], ["updated_at", "2024-01-01 14:50:24.201717"]]
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+  [1m[36mTRANSACTION (1.1ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:47:in `create'
+Completed 200 OK in 38ms (Views: 0.6ms | ActiveRecord: 9.4ms | Allocations: 12657)
+
+
+Started POST "/api/v1/show/27" for ::1 at 2024-01-01 22:50:24 +0800
+Started POST "/api/v1/show/27" for ::1 at 2024-01-01 22:50:24 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"27", "post"=>{}}
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"27", "post"=>{}}
+  [1m[36mPost Load (1.8ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 27], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:165:in `set_post'
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 11ms (Views: 0.5ms | ActiveRecord: 2.3ms | Allocations: 2920)
+
+
+  [1m[36mPost Load (0.4ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 27], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:165:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 20ms (Views: 0.6ms | ActiveRecord: 7.2ms | Allocations: 5209)
+
+
+Started POST "/api/v1/show/27" for ::1 at 2024-01-01 22:52:06 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"27", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 27], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:165:in `set_post'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 6ms (Views: 0.5ms | ActiveRecord: 0.7ms | Allocations: 1149)
+
+
+Started PATCH "/api/v1/update/27" for ::1 at 2024-01-01 22:52:13 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "title"=>"t", "category"=>"t", "content"=>"t", "id"=>"27", "post"=>{"title"=>"t", "content"=>"t", "category"=>"t"}}
+[31mUnpermitted parameters: :title, :category, :content. Context: { controller: Api::V1::PostsController, action: update, request: #<ActionDispatch::Request:0x00007f8629804ec0>, params: {"token"=>"[FILTERED]", "title"=>"t", "category"=>"t", "content"=>"t", "controller"=>"api/v1/posts", "action"=>"update", "id"=>"27", "post"=>{"title"=>"t", "content"=>"t", "category"=>"t"}} }[0m
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 27], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:165:in `set_post'
+[31mUnpermitted parameters: :title, :category, :content. Context: { controller: Api::V1::PostsController, action: update, request: #<ActionDispatch::Request:0x00007f8629804ec0>, params: {"token"=>"[FILTERED]", "title"=>"t", "category"=>"t", "content"=>"t", "controller"=>"api/v1/posts", "action"=>"update", "id"=>"27", "post"=>{"title"=>"t", "content"=>"t", "category"=>"t"}} }[0m
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 5ms (Views: 0.3ms | ActiveRecord: 0.5ms | Allocations: 1543)
+
+
+Started POST "/api/v1/show/27" for ::1 at 2024-01-01 22:53:02 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"27", "post"=>{}}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 27], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:165:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 5ms (Views: 0.6ms | ActiveRecord: 0.6ms | Allocations: 1149)
+
+
+Started POST "/api/v1/show/27" for ::1 at 2024-01-01 22:53:05 +0800
+Processing by Api::V1::PostsController#show as */*
+  Parameters: {"token"=>"[FILTERED]", "id"=>"27", "post"=>{}}
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 27], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:165:in `set_post'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+Completed 200 OK in 7ms (Views: 0.7ms | ActiveRecord: 0.8ms | Allocations: 1149)
+
+
+Started PATCH "/api/v1/update/27" for ::1 at 2024-01-01 22:53:24 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "post"=>{"title"=>"t", "category"=>"t", "content"=>"t"}, "id"=>"27"}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 27], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:165:in `set_post'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:132:in `authenticate_user'
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:57:in `update'
+  [1m[36mPost Update (2.5ms)[0m  [1m[33mUPDATE "posts" SET "title" = $1, "content" = $2, "category" = $3, "updated_at" = $4 WHERE "posts"."id" = $5[0m  [["title", nil], ["content", nil], ["category", nil], ["updated_at", "2024-01-01 14:53:24.165482"], ["id", 27]]
+  ↳ app/controllers/api/v1/posts_controller.rb:57:in `update'
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[31mROLLBACK[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:57:in `update'
+Completed 500 Internal Server Error in 9ms (ActiveRecord: 3.3ms | Allocations: 2947)
+
+
+  
+ActiveRecord::NotNullViolation (PG::NotNullViolation: ERROR:  null value in column "title" of relation "posts" violates not-null constraint
+DETAIL:  Failing row contains (27, 1, null, null, null, 0, 0, 2024-01-01 14:50:24.201717, 2024-01-01 14:53:24.165482).
+):
+  
+Started PATCH "/api/v1/update/27" for ::1 at 2024-01-01 22:54:00 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "post"=>{"title"=>"t", "category"=>"t", "content"=>"t"}, "id"=>"27"}
+  [1m[36mPost Load (0.2ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 27], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:166:in `set_post'
+  [1m[36mUser Load (0.6ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:133:in `authenticate_user'
+Completed 200 OK in 27ms (Views: 0.4ms | ActiveRecord: 7.8ms | Allocations: 8759)
+
+
+Started PATCH "/api/v1/update/27" for ::1 at 2024-01-01 22:54:10 +0800
+Processing by Api::V1::PostsController#update as */*
+  Parameters: {"token"=>"[FILTERED]", "post"=>{"title"=>"t", "category"=>"tf", "content"=>"t"}, "id"=>"27"}
+  [1m[36mPost Load (0.3ms)[0m  [1m[34mSELECT "posts".* FROM "posts" WHERE "posts"."id" = $1 LIMIT $2[0m  [["id", 27], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:166:in `set_post'
+  [1m[36mUser Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:133:in `authenticate_user'
+  [1m[36mTRANSACTION (0.2ms)[0m  [1m[35mBEGIN[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:58:in `update'
+  [1m[36mPost Update (1.6ms)[0m  [1m[33mUPDATE "posts" SET "category" = $1, "updated_at" = $2 WHERE "posts"."id" = $3[0m  [["category", "tf"], ["updated_at", "2024-01-01 14:54:10.214865"], ["id", 27]]
+  ↳ app/controllers/api/v1/posts_controller.rb:58:in `update'
+  [1m[36mTRANSACTION (1.2ms)[0m  [1m[35mCOMMIT[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:58:in `update'
+Completed 200 OK in 12ms (Views: 0.5ms | ActiveRecord: 3.3ms | Allocations: 2828)
+
+
+Started GET "/api/v1/show/27" for ::1 at 2024-01-01 23:00:26 +0800
+  
+ActionController::RoutingError (No route matches [GET] "/api/v1/show/27"):
+  
+Started GET "/api/v1/show/27" for ::1 at 2024-01-01 23:00:26 +0800
+  
+ActionController::RoutingError (No route matches [GET] "/api/v1/show/27"):
+  
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 23:00:26 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (1.1ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.4ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.5ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 30ms (Views: 1.3ms | ActiveRecord: 5.8ms | Allocations: 11951)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 23:00:26 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 6ms (Views: 0.5ms | ActiveRecord: 1.3ms | Allocations: 1838)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 23:01:24 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.7ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.3ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 6ms (Views: 0.6ms | ActiveRecord: 1.1ms | Allocations: 1836)
+
+
+Started GET "/api/v1/posts/index" for ::1 at 2024-01-01 23:01:24 +0800
+Processing by Api::V1::PostsController#index as */*
+  [1m[36mPost Load (0.6ms)[0m  [1m[34mSELECT "posts".* FROM "posts" ORDER BY "posts"."created_at" DESC[0m
+  ↳ app/controllers/api/v1/posts_controller.rb:7:in `map'
+  [1m[36mUser Load (0.2ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 1], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mUser Load (0.1ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+  [1m[36mCACHE User Load (0.0ms)[0m  [1m[34mSELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2[0m  [["id", 2], ["LIMIT", 1]]
+  ↳ app/controllers/api/v1/posts_controller.rb:8:in `block in index'
+Completed 200 OK in 6ms (Views: 0.5ms | ActiveRecord: 1.0ms | Allocations: 1836)
+
+


### PR DESCRIPTION
can now delete and update posts/threads
Note:
there were unpermitted parameters errors in backend, that is currently bypassed using
`params.permit(:token, :id, post:{})`
in both the authenticate_user function and set_post function. Might cause an issue in future.